### PR TITLE
lower minimum ipython version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 All notable changes will be documented here.
 
 ---
-
+## `1.0.4`
+_2022-05-06_
+### **Fixed**
+* Lowered the minimum required `ipython` version from `8.2.0` to `7.31.1`
+  
 ## `1.0.3`
 _2022-04-26_
 ### **Fixed**

--- a/dx/__init__.py
+++ b/dx/__init__.py
@@ -2,4 +2,4 @@ from .config import *
 from .dx import *
 from .formatters import *
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dx"
-version = "1.0.3"
+version = "1.0.4"
 description = "Python wrapper for Data Explorer"
 authors = ["Dave Shoup <dave.shoup@gmail.com>", "Kyle Kelley <rgbkrk@gmail.com>"]
 readme = "README.md"
@@ -12,7 +12,7 @@ keywords = ["data", "exploration", "visualization"]
 [tool.poetry.dependencies]
 python = "^3.8"
 pandas = "^1.3.5"
-ipython = "^8.2.0"
+ipython = ">=7.31.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
`dx<=1.0.3` required `ipython>=8.2.0` -- this lowers to `ipython>=7.31.1`