### PR TITLE
disable stringify index values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes will be documented here.
 
 ---
+## Unreleased
+
+### Changed
+- `STRINGIFY_INDEX_VALUES` is `False` by default (index `.name` will still be a string, but values will keep their original type)
+
 ## `1.2.0`
 _2022-08-21_
 

--- a/dx/formatters/dataresource.py
+++ b/dx/formatters/dataresource.py
@@ -35,7 +35,7 @@ class DataResourceSettings(BaseSettings):
 
     DATARESOURCE_FLATTEN_INDEX_VALUES: bool = False
     DATARESOURCE_FLATTEN_COLUMN_VALUES: bool = True
-    DATARESOURCE_STRINGIFY_INDEX_VALUES: bool = True
+    DATARESOURCE_STRINGIFY_INDEX_VALUES: bool = False
     DATARESOURCE_STRINGIFY_COLUMN_VALUES: bool = True
 
     class Config:

--- a/dx/formatters/dx.py
+++ b/dx/formatters/dx.py
@@ -34,7 +34,7 @@ class DXSettings(BaseSettings):
 
     DX_FLATTEN_INDEX_VALUES: bool = False
     DX_FLATTEN_COLUMN_VALUES: bool = True
-    DX_STRINGIFY_INDEX_VALUES: bool = True
+    DX_STRINGIFY_INDEX_VALUES: bool = False
     DX_STRINGIFY_COLUMN_VALUES: bool = True
 
     class Config:


### PR DESCRIPTION
disabling this prevents things like columns with `dtype` values from being used as an index, but should help filtering on the frontend