### PR TITLE
add sampling history

### DIFF
--- a/dx/comms.py
+++ b/dx/comms.py
@@ -1,70 +1,56 @@
+import logging
+
 import structlog
 from IPython import get_ipython
+from IPython.core.interactiveshell import InteractiveShell
 
-from dx.settings import get_settings
-from dx.types import DEXFilterSettings
+from dx.filtering import handle_resample
 
-settings = get_settings()
 logger = structlog.get_logger(__name__)
+
+
+def log(msg: str, level: int = logging.DEBUG):
+    """
+    Log a message to the DX logger.
+    """
+    logger.log(level, msg)
 
 
 # ref: https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-frontend
 def target_func(comm, open_msg):
     @comm.on_msg
     def _recv(msg):
-        from dx.filtering import update_display_id
+
+        content = msg.get("content", {})
+        if not content:
+            log(f"no 'content' in {msg=}", logging.DEBUG)
+            return
+
+        data = content.get("data", {})
+        if not data:
+            log(f"no 'data' in {msg['data']=}", logging.DEBUG)
+            return
 
         data = msg["content"]["data"]
-        # should look like this:
-        # {
-        #     "display_id": "1c1c8b40-f1f4-4205-931d-644a42e8232d",
-        #     "sampling": {
-        #         "filters": [
-        #             {
-        #                 "column": "float_column",
-        #                 "type": "METRIC_FILTER",
-        #                 "predicate": "between",
-        #                 "value": [0.5346270287577823, 0.673002123739554],
-        #             }
-        #         ],
-        #     },
-        #     "sample_size": 10000,
-        #     "status": "submitted",
-        # }
 
-        raw_dex_filters = data["sampling"]["filters"]
-        sample_size = data["sampling"]["sample_size"]
-        update_params = {
-            "display_id": data["display_id"],
-            "sql_query": f"SELECT * FROM {{table_name}} LIMIT {sample_size}",
-            "filters": raw_dex_filters,
-            "limit": sample_size,
-        }
-
-        if raw_dex_filters:
-            dex_filters = DEXFilterSettings(filters=raw_dex_filters)
-            # used to give a pandas query string to the user
-            pandas_filter_str = dex_filters.to_pandas_query()
-            # used to actually filter the data
-            sql_filter_str = dex_filters.to_sql_query()
-            update_params.update(
-                {
-                    "pandas_filter": pandas_filter_str,
-                    "sql_filter": f"SELECT * FROM {{table_name}} WHERE {sql_filter_str} LIMIT {sample_size}",
-                    "filters": raw_dex_filters,
-                }
-            )
-
-        update_display_id(**update_params)
+        if "display_id" in data and "filters" in data:
+            # TODO: check for explicit resample value?
+            handle_resample(data)
 
     comm.send({"connected": True})
 
 
-ipython_shell = get_ipython()
-if (
-    ipython_shell is not None
-    and getattr(ipython_shell, "kernel", None)
-    and settings.ENABLE_DATALINK
-):
-    COMM_MANAGER = ipython_shell.kernel.comm_manager
-    COMM_MANAGER.register_target("datalink", target_func)
+def register_comm(ipython_shell: InteractiveShell) -> None:
+    """
+    Registers the comm target function with the IPython kernel.
+    """
+    from dx.settings import get_settings
+
+    if not get_settings().ENABLE_DATALINK:
+        return
+
+    ipython_shell.kernel.comm_manager.register_target("datalink", target_func)
+
+
+if (ipython := get_ipython()) is not None:
+    register_comm(ipython)

--- a/dx/comms.py
+++ b/dx/comms.py
@@ -2,6 +2,7 @@ import structlog
 from IPython import get_ipython
 
 from dx.settings import get_settings
+from dx.types import DEXFilterSettings
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -14,15 +15,47 @@ def target_func(comm, open_msg):
         from dx.filtering import update_display_id
 
         data = msg["content"]["data"]
-        if "display_id" in data:
-            update_display_id(
-                display_id=data["display_id"],
-                pandas_filter=data.get("pandas_filter"),
-                sql_filter=data.get("sql_filter"),
-                filters=data.get("filters"),
-                output_variable_name=data.get("output_variable_name"),
-                limit=data["limit"],
+        # should look like this:
+        # {
+        #     "display_id": "1c1c8b40-f1f4-4205-931d-644a42e8232d",
+        #     "sampling": {
+        #         "filters": [
+        #             {
+        #                 "column": "float_column",
+        #                 "type": "METRIC_FILTER",
+        #                 "predicate": "between",
+        #                 "value": [0.5346270287577823, 0.673002123739554],
+        #             }
+        #         ],
+        #     },
+        #     "sample_size": 10000,
+        #     "status": "submitted",
+        # }
+
+        raw_dex_filters = data["sampling"]["filters"]
+        sample_size = data["sampling"]["sample_size"]
+        update_params = {
+            "display_id": data["display_id"],
+            "sql_query": f"SELECT * FROM {{table_name}} LIMIT {sample_size}",
+            "filters": raw_dex_filters,
+            "limit": sample_size,
+        }
+
+        if raw_dex_filters:
+            dex_filters = DEXFilterSettings(filters=raw_dex_filters)
+            # used to give a pandas query string to the user
+            pandas_filter_str = dex_filters.to_pandas_query()
+            # used to actually filter the data
+            sql_filter_str = dex_filters.to_sql_query()
+            update_params.update(
+                {
+                    "pandas_filter": pandas_filter_str,
+                    "sql_filter": f"SELECT * FROM {{table_name}} WHERE {sql_filter_str} LIMIT {sample_size}",
+                    "filters": raw_dex_filters,
+                }
             )
+
+        update_display_id(**update_params)
 
     comm.send({"connected": True})
 

--- a/dx/dx.py
+++ b/dx/dx.py
@@ -11,7 +11,7 @@ from dx.types import DXDisplayMode
 
 def display(
     data: Union[List[dict], pd.DataFrame, Union[pathlib.Path, str]],
-    mode: DXDisplayMode = DXDisplayMode.simple,
+    mode: DXDisplayMode = DXDisplayMode.enhanced,
     ipython_shell: Optional[InteractiveShell] = None,
 ) -> None:
     """

--- a/dx/filtering.py
+++ b/dx/filtering.py
@@ -8,6 +8,7 @@ from IPython.display import update_display
 from dx.formatters.callouts import display_callout
 from dx.sampling import get_df_dimensions
 from dx.settings import get_settings, settings_context
+from dx.types import DEXFilterSettings
 from dx.utils.tracking import (
     DATAFRAME_HASH_TO_VAR_NAME,
     DISPLAY_ID_TO_DATAFRAME_HASH,
@@ -140,3 +141,49 @@ def update_display_id(
             display_id=display_id + "-primary",
             update=True,
         )
+
+
+def handle_resample(data: dict) -> None:
+    # TODO: add resample message to types.py
+    # `data` should look like this:
+    # {
+    #     "display_id": "1c1c8b40-f1f4-4205-931d-644a42e8232d",
+    #     "sampling": {
+    #         "filters": [
+    #             {
+    #                 "column": "float_column",
+    #                 "type": "METRIC_FILTER",
+    #                 "predicate": "between",
+    #                 "value": [0.5346270287577823, 0.673002123739554],
+    #             }
+    #         ],
+    #         "sample_size": 10000,
+    #     },
+    #     "status": "submitted",
+    # }
+
+    raw_filters = data["filters"]
+    sample_size = data["limit"]
+
+    update_params = {
+        "display_id": data["display_id"],
+        "sql_query": f"SELECT * FROM {{table_name}} LIMIT {sample_size}",
+        "filters": raw_filters,
+        "limit": sample_size,
+    }
+
+    if raw_filters:
+        dex_filters = DEXFilterSettings(filters=raw_filters)
+        # used to give a pandas query string to the user
+        pandas_filter_str = dex_filters.to_pandas_query()
+        # used to actually filter the data
+        sql_filter_str = dex_filters.to_sql_query()
+        update_params.update(
+            {
+                "pandas_filter": pandas_filter_str,
+                "sql_filter": f"SELECT * FROM {{table_name}} WHERE {sql_filter_str} LIMIT {sample_size}",
+                "filters": raw_filters,
+            }
+        )
+
+    update_display_id(**update_params)

--- a/dx/types.py
+++ b/dx/types.py
@@ -1,4 +1,10 @@
 import enum
+from datetime import datetime
+from typing import List, Literal, Union
+
+import pandas as pd
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class DXDisplayMode(enum.Enum):
@@ -25,3 +31,121 @@ class DXSamplingMethod(enum.Enum):
 
     def __eq__(self, other):
         return str(other) == self.value
+
+
+class DEXMediaType(enum.Enum):
+    dataresource = "application/vnd.dataresource+json"
+    dex = "application/vnd.dex.v1+json"
+
+    def __str__(self):
+        return self.value
+
+
+class DEXDateFilter(BaseModel):
+    column: str
+    type: Literal["DATE_FILTER"] = "DATE_FILTER"
+    predicate: Literal["between"] = "between"
+
+    start: datetime
+    end: datetime
+
+    @property
+    def _pd_column(self):
+        return clean_pandas_column(self.column)
+
+    @property
+    def sql_filter(self) -> str:
+        sql_time_fmt = "%Y-%m-%dT%H:%M:%S.%f"  # yyyy-mm-ddThh:mi:ss.mmm
+        start_timestamp = pd.Timestamp(self.start).strftime(sql_time_fmt)
+        end_timestamp = pd.Timestamp(self.end).strftime(sql_time_fmt)
+        date_filter_min = f""""{self.column}" >= '{start_timestamp}'"""
+        date_filter_max = f""""{self.column}" <= '{end_timestamp}'"""
+        return f"{date_filter_min} AND {date_filter_max}"
+
+    @property
+    def pandas_filter(self) -> str:
+        # any kind of .to_pydatetime() conversion will likely raise
+        # InvalidComparison errors between pd.Timestamp and np.datetime64,
+        # but the frontend passes UTC time, while the data may not have tzinfo
+        start_timestamp = pd.Timestamp(self.start).tz_localize(None)
+        end_timestamp = pd.Timestamp(self.end).tz_localize(None)
+        date_filter_min = f"""({self._pd_column} >= "{start_timestamp}")"""
+        date_filter_max = f"""({self._pd_column} <= "{end_timestamp}")"""
+        return f"({date_filter_min} & {date_filter_max})"
+
+
+class DEXDimensionFilter(BaseModel):
+    column: str
+    type: Literal["DIMENSION_FILTER"] = "DIMENSION_FILTER"
+    predicate: Literal["in"] = "in"
+
+    value: list
+
+    @property
+    def _pd_column(self):
+        return clean_pandas_column(self.column)
+
+    @property
+    def sql_filter(self) -> str:
+        quote_scaped_vals = [v.replace("'", "''").replace('"', '""') for v in self.value]
+        filter_values_str = ", ".join([f"'{v}'" for v in quote_scaped_vals])
+        return f""""{self.column}" IN ({filter_values_str})"""
+
+    @property
+    def pandas_filter(self) -> str:
+        return f"""({self._pd_column} in {self.value})"""
+
+
+class DEXMetricFilter(BaseModel):
+    column: str
+    type: Literal["METRIC_FILTER"] = "METRIC_FILTER"
+    predicate: Literal["between"] = "between"
+
+    value: list
+
+    @property
+    def _pd_column(self):
+        return clean_pandas_column(self.column)
+
+    @property
+    def sql_filter(self) -> str:
+        metric_filter_min = f""""{self.column}" >= {self.value[0]}"""
+        metric_filter_max = f""""{self.column}" <= {self.value[1]}"""
+        return f"{metric_filter_min} AND {metric_filter_max}"
+
+    @property
+    def pandas_filter(self) -> str:
+        # `.between()` has issues here depending on the column name structure
+        metric_filter_min = f"""({self._pd_column} >= {self.value[0]})"""
+        metric_filter_max = f"""({self._pd_column} <= {self.value[1]})"""
+        return f"({metric_filter_min} & {metric_filter_max})"
+
+
+def clean_pandas_column(column: str) -> str:
+    """
+    Converts column names into a more pandas .query()-friendly format.
+    """
+    # pandas will raise errors if the columns are numeric
+    # e.g. "UndefinedVariableError: name 'BACKTICK_QUOTED_STRING_{column}' is not defined"
+    # so we have to refer to them as pd.Series object using `@df[column]` structure
+    # except we don't know the name of the variable here, so we pass {df_name} as a placeholder
+    # to be filled in by the kernel*
+    # ---
+    # *as of August 2022, the dx package is using this for Datalink processing and filling df_name
+    # as part of its internal tracking
+    if str(column).isdigit() or str(column).isdecimal():
+        return f"@{{df_name}}[{column}]"
+    return f"`{column}`"
+
+
+FilterTypes = Union[DEXDateFilter, DEXDimensionFilter, DEXMetricFilter]
+
+
+class DEXFilterSettings(BaseModel):
+    filters: List[Annotated[FilterTypes, Field(discriminator="type")]] = []
+
+    def to_sql_query(self) -> str:
+        return " AND ".join([f.sql_filter for f in self.filters])
+
+    def to_pandas_query(self) -> str:
+        return " & ".join([f.pandas_filter for f in self.filters])


### PR DESCRIPTION
- parse DEX filters and convert to pandas/sql query syntax strings
- add sampling history during `update_display_id()`
- use DXDataFrameCache instead of abusing globals
- set 50k hard limit for rendering