### PR TITLE
convert filters to pandas/sql query syntax

### DIFF
--- a/dx/filtering.py
+++ b/dx/filtering.py
@@ -167,7 +167,7 @@ def handle_resample(data: dict) -> None:
 
     update_params = {
         "display_id": data["display_id"],
-        "sql_query": f"SELECT * FROM {{table_name}} LIMIT {sample_size}",
+        "sql_filter": f"SELECT * FROM {{table_name}} LIMIT {sample_size}",
         "filters": raw_filters,
         "limit": sample_size,
     }

--- a/dx/formatters/dataresource.py
+++ b/dx/formatters/dataresource.py
@@ -161,14 +161,12 @@ def format_dataresource(
 
     payload = generate_dataresource_body(df, display_id=display_id)
 
-    metadata = generate_metadata(display_id=display_id)
-    metadata["datalink"]["dataframe_info"].update(
-        {
-            "default_index_used": has_default_index,
-            **orig_df_dimensions,
-            **sampled_df_dimensions,
-        }
-    )
+    dataframe_info = {
+        "default_index_used": has_default_index,
+        **orig_df_dimensions,
+        **sampled_df_dimensions,
+    }
+    metadata = generate_metadata(display_id=display_id, **dataframe_info)
 
     if display_id not in DISPLAY_ID_TO_METADATA:
         DISPLAY_ID_TO_METADATA[display_id] = metadata

--- a/dx/formatters/dx.py
+++ b/dx/formatters/dx.py
@@ -149,7 +149,6 @@ def format_dx(
     df: pd.DataFrame,
     update: bool = False,
     display_id: Optional[str] = None,
-    filters: Optional[list] = None,
     has_default_index: bool = True,
 ) -> tuple:
     display_id = display_id or str(uuid.uuid4())
@@ -161,14 +160,12 @@ def format_dx(
 
     payload = generate_dx_body(df, display_id=display_id)
 
-    metadata = generate_metadata(display_id=display_id)
-    metadata["datalink"]["dataframe_info"].update(
-        {
-            "default_index_used": has_default_index,
-            **orig_df_dimensions,
-            **sampled_df_dimensions,
-        }
-    )
+    dataframe_info = {
+        "default_index_used": has_default_index,
+        **orig_df_dimensions,
+        **sampled_df_dimensions,
+    }
+    metadata = generate_metadata(display_id=display_id, **dataframe_info)
 
     if display_id not in DISPLAY_ID_TO_METADATA:
         DISPLAY_ID_TO_METADATA[display_id] = metadata
@@ -178,6 +175,7 @@ def format_dx(
 
     # this needs to happen so we can update by display_id as needed
     with pd.option_context("html.table_schema", dx_settings.DX_HTML_TABLE_SCHEMA):
+        logger.debug(f"displaying DEX payload in {display_id=}")
         display(
             payload,
             raw=True,

--- a/dx/settings.py
+++ b/dx/settings.py
@@ -35,7 +35,7 @@ def get_default_renderable_types():
 
 
 class Settings(BaseSettings):
-    LOG_LEVEL: Union[int, str] = logging.DEBUG
+    LOG_LEVEL: Union[int, str] = logging.WARNING
 
     DISPLAY_MAX_ROWS: int = 60
     DISPLAY_MAX_COLUMNS: int = 20

--- a/dx/settings.py
+++ b/dx/settings.py
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     DATETIME_STRING_FORMAT: str = "%Y-%m-%dT%H:%M:%S.%f"
 
     # controls dataframe variable tracking, hashing, and storing in sqlite
-    ENABLE_DATALINK: bool = True
+    ENABLE_DATALINK: bool = False
     NUM_PAST_SAMPLES_TRACKED: int = 3
 
     @validator("RENDERABLE_OBJECTS", pre=True, always=True)

--- a/dx/types.py
+++ b/dx/types.py
@@ -1,4 +1,10 @@
 import enum
+from datetime import datetime
+from typing import List, Literal, Union
+
+import pandas as pd
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class DXDisplayMode(enum.Enum):
@@ -25,3 +31,121 @@ class DXSamplingMethod(enum.Enum):
 
     def __eq__(self, other):
         return str(other) == self.value
+
+
+class DEXMediaType(enum.Enum):
+    dataresource = "application/vnd.dataresource+json"
+    dex = "application/vnd.dex.v1+json"
+
+    def __str__(self):
+        return self.value
+
+
+class DEXDateFilter(BaseModel):
+    column: str
+    type: Literal["DATE_FILTER"] = "DATE_FILTER"
+    predicate: Literal["between"] = "between"
+
+    start: datetime
+    end: datetime
+
+    @property
+    def _pd_column(self):
+        return clean_pandas_column(self.column)
+
+    @property
+    def sql_filter(self) -> str:
+        sql_time_fmt = "%Y-%m-%dT%H:%M:%S.%f"  # yyyy-mm-ddThh:mi:ss.mmm
+        start_timestamp = pd.Timestamp(self.start).strftime(sql_time_fmt)
+        end_timestamp = pd.Timestamp(self.end).strftime(sql_time_fmt)
+        date_filter_min = f""""{self.column}" >= '{start_timestamp}'"""
+        date_filter_max = f""""{self.column}" <= '{end_timestamp}'"""
+        return f"{date_filter_min} AND {date_filter_max}"
+
+    @property
+    def pandas_filter(self) -> str:
+        # any kind of .to_pydatetime() conversion will likely raise
+        # InvalidComparison errors between pd.Timestamp and np.datetime64,
+        # but the frontend passes UTC time, while the data may not have tzinfo
+        start_timestamp = pd.Timestamp(self.start).tz_localize(None)
+        end_timestamp = pd.Timestamp(self.end).tz_localize(None)
+        date_filter_min = f"""({self._pd_column} >= "{start_timestamp}")"""
+        date_filter_max = f"""({self._pd_column} <= "{end_timestamp}")"""
+        return f"({date_filter_min} & {date_filter_max})"
+
+
+class DEXDimensionFilter(BaseModel):
+    column: str
+    type: Literal["DIMENSION_FILTER"] = "DIMENSION_FILTER"
+    predicate: Literal["in"] = "in"
+
+    value: list
+
+    @property
+    def _pd_column(self):
+        return clean_pandas_column(self.column)
+
+    @property
+    def sql_filter(self) -> str:
+        quote_scaped_vals = [v.replace("'", "''").replace('"', '""') for v in self.value]
+        filter_values_str = ", ".join([f"'{v}'" for v in quote_scaped_vals])
+        return f""""{self.column}" IN ({filter_values_str})"""
+
+    @property
+    def pandas_filter(self) -> str:
+        return f"""({self._pd_column} in {self.value})"""
+
+
+class DEXMetricFilter(BaseModel):
+    column: str
+    type: Literal["METRIC_FILTER"] = "METRIC_FILTER"
+    predicate: Literal["between"] = "between"
+
+    value: list
+
+    @property
+    def _pd_column(self):
+        return clean_pandas_column(self.column)
+
+    @property
+    def sql_filter(self) -> str:
+        metric_filter_min = f""""{self.column}" >= {self.value[0]}"""
+        metric_filter_max = f""""{self.column}" <= {self.value[1]}"""
+        return f"{metric_filter_min} AND {metric_filter_max}"
+
+    @property
+    def pandas_filter(self) -> str:
+        # `.between()` has issues here depending on the column name structure
+        metric_filter_min = f"""({self._pd_column} >= {self.value[0]})"""
+        metric_filter_max = f"""({self._pd_column} <= {self.value[1]})"""
+        return f"({metric_filter_min} & {metric_filter_max})"
+
+
+def clean_pandas_column(column: str) -> str:
+    """
+    Converts column names into a more pandas .query()-friendly format.
+    """
+    # pandas will raise errors if the columns are numeric
+    # e.g. "UndefinedVariableError: name 'BACKTICK_QUOTED_STRING_{column}' is not defined"
+    # so we have to refer to them as pd.Series object using `@df[column]` structure
+    # except we don't know the name of the variable here, so we pass {df_name} as a placeholder
+    # to be filled in by the kernel*
+    # ---
+    # *as of August 2022, the dx package is using this for Datalink processing and filling df_name
+    # as part of its internal tracking
+    if str(column).isdigit() or str(column).isdecimal():
+        return f"@{{df_name}}[{column}]"
+    return f"`{column}`"
+
+
+FilterTypes = Union[DEXDateFilter, DEXDimensionFilter, DEXMetricFilter]
+
+
+class DEXFilterSettings(BaseModel):
+    filters: List[Annotated[FilterTypes, Field(discriminator="type")]] = []
+
+    def to_sql_query(self) -> str:
+        return " AND ".join([f.sql_filter for f in self.filters])
+
+    def to_pandas_query(self) -> str:
+        return " & ".join([f.pandas_filter for f in self.filters])

--- a/dx/utils/formatting.py
+++ b/dx/utils/formatting.py
@@ -164,16 +164,16 @@ def clean_column_values_for_sqlite(s: pd.Series) -> pd.Series:
     return s
 
 
-def generate_metadata(display_id: str):
+def generate_metadata(display_id: str, **dataframe_info):
     from dx.utils.tracking import DISPLAY_ID_TO_FILTERS, DISPLAY_ID_TO_METADATA
 
     # these are set whenever store_sample_to_history() is called after a filter action from the frontend
     filters = DISPLAY_ID_TO_FILTERS.get(display_id, [])
     existing_metadata = DISPLAY_ID_TO_METADATA.get(display_id, {})
-    sample_history = existing_metadata.get('datalink', {}).get("sample_history", [])
+    sample_history = existing_metadata.get("datalink", {}).get("sample_history", [])
     metadata = {
         "datalink": {
-            "dataframe_info": {},
+            "dataframe_info": dataframe_info,
             "dx_settings": settings.dict(
                 exclude={
                     "RENDERABLE_OBJECTS": True,

--- a/dx/utils/formatting.py
+++ b/dx/utils/formatting.py
@@ -26,12 +26,22 @@ def human_readable_size(size_bytes: int) -> str:
 
 def is_default_index(index: pd.Index) -> bool:
     """
-    Returns True if the index values are 0-n, where n is the number of items in the series.
+    Returns True if the index have no specified name,
+    are of `int` type, and are a pd.Index (instead of pd.MultiIndex).
     """
-    index_vals = index.values.tolist()
-    default_index = pd.Index(list(range(len(index_vals))))
-    index = pd.Index(sorted(index_vals))
-    return index.equals(default_index)
+    if isinstance(index, pd.MultiIndex):
+        return False
+
+    if index.dtype != "int":
+        return False
+
+    if index.name is not None:
+        return False
+
+    # we aren't checking for 0-n row values because any kind of
+    # filtering or sampling will create gaps and incorrectly
+    # mark this as a non-default index (return False)
+    return True
 
 
 def normalize_index_and_columns(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
- migrating the DEX filter parsing into SQL and pandas queries away from Planar Ally
- fixing `dataframe_info` and `default_index_used` checks for metadata sent to the frontend
- setting logging back to `WARNING` level
- set `ENABLE_DATALINK=False` - should be set as env before import