### PR TITLE
accept `cell_id` in comm msg data

### DIFF
--- a/dx/filtering.py
+++ b/dx/filtering.py
@@ -61,9 +61,16 @@ def update_display_id(
     filters: Optional[list] = None,
     output_variable_name: Optional[str] = None,
     limit: Optional[int] = None,
+    cell_id: Optional[str] = None,
 ) -> None:
     """
     Filters the dataframe in the cell with the given display_id.
+    This is done by executing the SQL filter on the table
+    associated with the given display ID.
+
+    This also associates the queried subset to the original dataset
+    (based on the display ID) so as to avoid re-registering a new
+    display handler.
     """
     from dx.utils.tracking import sql_engine
 
@@ -170,6 +177,7 @@ def handle_resample(data: dict) -> None:
         "sql_filter": f"SELECT * FROM {{table_name}} LIMIT {sample_size}",
         "filters": raw_filters,
         "limit": sample_size,
+        "cell_id": data["cell_id"],
     }
 
     if raw_filters:

--- a/dx/settings.py
+++ b/dx/settings.py
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     DATETIME_STRING_FORMAT: str = "%Y-%m-%dT%H:%M:%S.%f"
 
     # controls dataframe variable tracking, hashing, and storing in sqlite
-    ENABLE_DATALINK: bool = False
+    ENABLE_DATALINK: bool = True
     NUM_PAST_SAMPLES_TRACKED: int = 3
 
     @validator("RENDERABLE_OBJECTS", pre=True, always=True)

--- a/dx/settings.py
+++ b/dx/settings.py
@@ -96,6 +96,8 @@ class Settings(BaseSettings):
     def validate_display_max_columns(cls, val):
         if val < 0:
             raise ValueError("DISPLAY_MAX_COLUMNS must be >= 0")
+        if val > 50_000:
+            raise ValueError("DISPLAY_MAX_COLUMNS must be <= 50000")
         pd.set_option("display.max_columns", val)
         return val
 

--- a/dx/tests/test_sampling.py
+++ b/dx/tests/test_sampling.py
@@ -24,7 +24,11 @@ def test_large_dataframe_is_sampled(sample_large_dataframe: pd.DataFrame):
     Test that a large dataframe is sampled to below the size of
     MAX_RENDER_SIZE_BYTES.
     """
-    with settings_context(MAX_RENDER_SIZE_BYTES=1024 * 1024):
+    with settings_context(
+        MAX_RENDER_SIZE_BYTES=1024 * 1024,
+        DISPLAY_MAX_ROWS=100,
+        DISPLAY_MAX_COLUMNS=100,
+    ):
         original_size_bytes = sys.getsizeof(sample_large_dataframe)
         sampled_df = sample_if_too_big(sample_large_dataframe)
         sampled_size_bytes = sys.getsizeof(sampled_df)
@@ -36,9 +40,14 @@ def test_sampled_dataframe_keeps_dtypes(sample_large_dataframe: pd.DataFrame):
     """
     Test that a sampled dataframe doesn't alter column datatypes.
     """
-    orig_dtypes = sample_large_dataframe.dtypes
-    sampled_df = sample_if_too_big(sample_large_dataframe)
-    assert (sampled_df.dtypes == orig_dtypes).all()
+    with settings_context(
+        MAX_RENDER_SIZE_BYTES=1024 * 1024,
+        DISPLAY_MAX_ROWS=100,
+        DISPLAY_MAX_COLUMNS=100,
+    ):
+        orig_dtypes = sample_large_dataframe.dtypes
+        sampled_df = sample_if_too_big(sample_large_dataframe)
+        assert (sampled_df.dtypes == orig_dtypes).all()
 
 
 def test_wide_dataframe_is_narrowed(sample_wide_dataframe: pd.DataFrame):

--- a/dx/utils/tracking.py
+++ b/dx/utils/tracking.py
@@ -25,9 +25,12 @@ sql_engine = create_engine("sqlite://", echo=False)
 # - an original uuid for each dataframe
 # - the hash of each dataframe so we aren't storing them multiple times
 # - the display ID associated with each *cleaned* dataframe
+# - the cell ID associated with the display ID, when passed during an update over comms
 # - before/after cleaning associations per dataframe
 # - any special column treatment (e.g. datetime columns)
 # TODO: create new classes to handle this instead of abusing globals.
+
+CELL_ID_TO_DISPLAY_ID = {}
 
 DATAFRAME_HASH_TO_DISPLAY_ID = {}
 DATAFRAME_HASH_TO_VAR_NAME = {}


### PR DESCRIPTION
- accepts `cell_id` when planar ally sends via `comm_msg` during a resample request (to be used later after discussion about cell_id:display_id associations)
- ensures `DISPLAY_MAX_ROWS` doesn't exceed 50k
- minor test speed-up to make "large" dataframes and sampling limits smaller