### PR TITLE
Dataframe renaming comms listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes will be documented here.
 
 ### Changed
 - `STRINGIFY_INDEX_VALUES` is `False` by default (index `.name` will still be a string, but values will keep their original type)
+- Added comms listener for renaming (SQL cell) dataframes.
 
 ## `1.2.0`
 _2022-08-21_

--- a/src/dx/comms.py
+++ b/src/dx/comms.py
@@ -40,9 +40,7 @@ def handle_resample_comm(msg):
 
 
 def renamer(comm, open_msg):
-    """
-    Rename a SQL cell dataframe.
-    """
+    """Rename a SQL cell dataframe."""
 
     @comm.on_msg
     def _recv(msg):
@@ -50,7 +48,7 @@ def renamer(comm, open_msg):
 
 
 def handle_renaming_comm(msg: dict, ipython_shell: Optional[InteractiveShell]):
-
+    """Implementation behind renaming a SQL cell dataframe via comms"""
     content = msg.get("content")
     if not content:
         return
@@ -79,7 +77,7 @@ def handle_renaming_comm(msg: dict, ipython_shell: Optional[InteractiveShell]):
             if data["new_name"]:
                 ipython_shell.user_ns[data["new_name"]] = value_to_rename
 
-            # But old name will always be present in message.
+            # But old name will always be present in message. Delete it now.
             del ipython_shell.user_ns[data["old_name"]]
 
 

--- a/src/dx/comms.py
+++ b/src/dx/comms.py
@@ -2,13 +2,15 @@ import structlog
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
 
+import pandas as pd
+
 from dx.filtering import handle_resample
 
 logger = structlog.get_logger(__name__)
 
 
 # ref: https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-frontend
-def target_func(comm, open_msg):
+def resampler(comm, open_msg):
     @comm.on_msg
     def _recv(msg):
 
@@ -29,20 +31,44 @@ def target_func(comm, open_msg):
     comm.send({"connected": True})
 
 
+def renamer(comm, open_msg):
+    @comm.on_msg
+    def _recv(msg):
+
+        content = msg.get("content", {})
+        if not content:
+            return
+
+        data = content.get("data", {})
+        if not data:
+            return
+
+        data = msg["content"]["data"]
+
+        if "old_name" in data and "new_name" in data:
+            to_rename = globals().get(data["old_name"])
+            if isinstance(to_rename, pd.DataFrame):
+                globals[data["new_name"]] = to_rename
+                del globals[data["old_name"]]
+
+    comm.send({"connected": True})
+
+
 def register_comm(ipython_shell: InteractiveShell) -> None:
     """
     Registers the comm target function with the IPython kernel.
     """
     from dx.settings import get_settings
 
-    if not get_settings().ENABLE_DATALINK:
-        return
-
     if getattr(ipython_shell, "kernel", None) is None:
         # likely a TerminalInteractiveShell
         return
 
-    ipython_shell.kernel.comm_manager.register_target("datalink", target_func)
+    if get_settings().ENABLE_DATALINK:
+        ipython_shell.kernel.comm_manager.register_target("datalink", resampler)
+
+    if get_settings().ENABLE_RENAMER:
+        ipython_shell.kernel.comm_manager.register_target("rename", renamer)
 
 
 if (ipython := get_ipython()) is not None:

--- a/src/dx/comms.py
+++ b/src/dx/comms.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
+import pandas as pd
 import structlog
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
-
-import pandas as pd
 
 from dx.filtering import handle_resample
 from dx.types import DEXResampleMessage

--- a/src/dx/comms.py
+++ b/src/dx/comms.py
@@ -46,7 +46,7 @@ def renamer(comm, open_msg):
         handle_renaming_comm(msg)
 
 
-def handle_renaming_comm(msg: dict, ipython_shell: Optional[InteractiveShell]):
+def handle_renaming_comm(msg: dict, ipython_shell: Optional[InteractiveShell] = None):
     """Implementation behind renaming a SQL cell dataframe via comms"""
     content = msg.get("content")
     if not content:

--- a/src/dx/comms.py
+++ b/src/dx/comms.py
@@ -46,10 +46,11 @@ def renamer(comm, open_msg):
         data = msg["content"]["data"]
 
         if "old_name" in data and "new_name" in data:
-            to_rename = globals().get(data["old_name"])
+            shell = get_ipython()
+            to_rename = shell.user_ns.get(data["old_name"])
             if isinstance(to_rename, pd.DataFrame):
-                globals[data["new_name"]] = to_rename
-                del globals[data["old_name"]]
+                shell.user_ns[data["new_name"]] = to_rename
+                del shell.user_ns[data["old_name"]]
 
     comm.send({"connected": True})
 

--- a/src/dx/settings.py
+++ b/src/dx/settings.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
 
     # controls dataframe variable tracking, hashing, and storing in sqlite
     ENABLE_DATALINK: bool = True
+    ENABLE_RENAMER: bool = True
     NUM_PAST_SAMPLES_TRACKED: int = 3
 
     @validator("RENDERABLE_OBJECTS", pre=True, always=True)

--- a/tests/test_resample_comm.py
+++ b/tests/test_resample_comm.py
@@ -1,11 +1,11 @@
-from dx.comms import handle_comm_msg
+from dx.comms import handle_resample_comm
 from dx.types import DEXResampleMessage
 
 
-def test_handle_comm_msg(mocker):
+def test_handle_resample_comm(mocker):
     """
     Test that `handle_resample` is called with the correctly
-    formatted resample message type if the comm receives
+    formatted resample message type if the comm (`handle_resample_comm`) receives
     the right data structure.
     """
     msg = {
@@ -24,12 +24,12 @@ def test_handle_comm_msg(mocker):
         }
     }
     mock_handle_resample = mocker.patch("dx.comms.handle_resample")
-    handle_comm_msg(msg)
+    handle_resample_comm(msg)
     resample_msg = DEXResampleMessage.parse_obj(msg["content"]["data"])
     mock_handle_resample.assert_called_once_with(resample_msg)
 
 
-def test_handle_comm_msg_skipped(mocker):
+def test_handle_resample_comm_skipped(mocker):
     """
     Test that `handle_resample` is not called with invalid data.
     """
@@ -41,5 +41,5 @@ def test_handle_comm_msg_skipped(mocker):
         }
     }
     mock_handle_resample = mocker.patch("dx.comms.handle_resample")
-    handle_comm_msg(msg)
+    handle_resample_comm(msg)
     mock_handle_resample.assert_not_called()


### PR DESCRIPTION
I added an untested dataframe renaming comms handler for review as part of the spike into how to manage non-executing output renaming.

Used by https://github.com/noteable-io/planar-ally/pull/299