### PR TITLE
fix for `index` not being set during resample

### DIFF
--- a/src/dx/utils/tracking.py
+++ b/src/dx/utils/tracking.py
@@ -124,6 +124,11 @@ def get_df_index(index: Union[pd.Index, pd.MultiIndex]):
     index_name = index.name
     if index_name is None and isinstance(index, pd.MultiIndex):
         index_name = index.names
+    if index_name is None:
+        # no custom index was used, but will be set to `index`
+        # before storing in the database, which we'll need to
+        # reset after any database querying
+        index_name = "index"
     return index_name
 
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -3,18 +3,20 @@ import pandas as pd
 import pytest
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 
-from dx.filtering import handle_resample, store_sample_to_history
+from dx.filtering import handle_resample, resample_from_db, store_sample_to_history
 from dx.formatters.main import handle_format
 from dx.settings import get_settings, settings_context
-from dx.types import DEXResampleMessage
+from dx.types import DEXFilterSettings, DEXResampleMessage
 from dx.utils.tracking import DXDF_CACHE, DXDataFrame
 
 settings = get_settings()
 
 
+@pytest.mark.parametrize("has_filters", [True, False])
 def test_store_sample_to_history(
     sample_dxdataframe: DXDataFrame,
     sample_dex_filters: list,
+    has_filters: bool,
 ):
     """
     Test that filters applied during sampling are added to
@@ -23,16 +25,30 @@ def test_store_sample_to_history(
     display_id = sample_dxdataframe.display_id
     DXDF_CACHE[display_id] = sample_dxdataframe
 
+    filters = []
+    if has_filters:
+        filters = sample_dex_filters
+
     store_sample_to_history(
         sample_dxdataframe.df,
         display_id,
-        sample_dex_filters,
+        filters,
     )
 
-    assert sample_dxdataframe.metadata["datalink"]["applied_filters"] == sample_dex_filters
+    assert sample_dxdataframe.metadata["datalink"]["applied_filters"] == filters
     assert sample_dxdataframe.metadata["datalink"]["sampling_time"] is not None
 
+    assert (
+        sample_dxdataframe.metadata["datalink"]["dataframe_info"]["orig_num_rows"]
+        == sample_dxdataframe.df.shape[0]
+    )
+    assert (
+        sample_dxdataframe.metadata["datalink"]["dataframe_info"]["orig_num_cols"]
+        == sample_dxdataframe.df.shape[1]
+    )
 
+
+@pytest.mark.parametrize("has_filters", [True, False])
 @pytest.mark.parametrize("display_mode", ["simple", "enhanced"])
 def test_resample_from_db(
     mocker,
@@ -41,6 +57,7 @@ def test_resample_from_db(
     sample_db_connection: duckdb.DuckDBPyConnection,
     sample_dex_filters: list,
     display_mode: str,
+    has_filters: bool,
 ):
     """
     Ensure dataframes stored in the kernel's local database
@@ -57,9 +74,13 @@ def test_resample_from_db(
             ipython_shell=get_ipython,
         )
 
+        filters = []
+        if has_filters:
+            filters = sample_dex_filters
+
         resample_msg = DEXResampleMessage(
             display_id=metadata[settings.MEDIA_TYPE]["display_id"],
-            filters=sample_dex_filters,
+            filters=filters,
             limit=50_000,
             cell_id=None,
         )
@@ -72,6 +93,7 @@ def test_resample_from_db(
             assert False, f"Resample failed with error: {e}"
 
 
+@pytest.mark.parametrize("has_filters", [True, False])
 @pytest.mark.parametrize("display_mode", ["simple", "enhanced"])
 def test_resample_groupby_from_db(
     mocker,
@@ -80,10 +102,11 @@ def test_resample_groupby_from_db(
     sample_db_connection: duckdb.DuckDBPyConnection,
     sample_dex_groupby_filters: list,
     display_mode: str,
+    has_filters: bool,
 ):
     """
-    Ensure dataframes stored in the kernel's local database
-    can be resampled with DEX-provided filters.
+    Ensure dataframes with pd.MultiIndex index/columns stored in
+    the kernel's local database can be resampled with DEX-provided filters.
     """
     get_ipython.user_ns["test_df"] = sample_groupby_dataframe
 
@@ -96,9 +119,13 @@ def test_resample_groupby_from_db(
             ipython_shell=get_ipython,
         )
 
+        filters = []
+        if has_filters:
+            filters = sample_dex_groupby_filters
+
         resample_msg = DEXResampleMessage(
             display_id=metadata[settings.MEDIA_TYPE]["display_id"],
-            filters=sample_dex_groupby_filters,
+            filters=filters,
             limit=50_000,
             cell_id=None,
         )
@@ -109,3 +136,57 @@ def test_resample_groupby_from_db(
             )
         except Exception as e:
             assert False, f"Resample failed with error: {e}"
+
+
+@pytest.mark.parametrize("has_filters", [True, False])
+@pytest.mark.parametrize("display_mode", ["simple", "enhanced"])
+def test_resample_keeps_original_structure(
+    mocker,
+    get_ipython: TerminalInteractiveShell,
+    sample_random_dataframe: pd.DataFrame,
+    sample_db_connection: duckdb.DuckDBPyConnection,
+    sample_dex_filters: list,
+    display_mode: str,
+    has_filters: bool,
+):
+    """
+    Ensure resampled dataframes have the same column/index structure
+    after resampling as the original dataframe.
+    """
+    get_ipython.user_ns["test_df"] = sample_random_dataframe
+
+    mocker.patch("dx.formatters.main.db_connection", sample_db_connection)
+    mocker.patch("dx.filtering.db_connection", sample_db_connection)
+
+    with settings_context(enable_datalink=True, display_mode=display_mode):
+        _, metadata = handle_format(
+            sample_random_dataframe,
+            ipython_shell=get_ipython,
+        )
+
+        sample_size = 50_000
+        dex_filters = DEXFilterSettings(filters=sample_dex_filters)
+        sql_filter_str = dex_filters.to_sql_query()
+        if has_filters:
+            sql_filter = f"SELECT * FROM {{table_name}} WHERE {sql_filter_str} LIMIT {sample_size}"
+            filters = sample_dex_filters
+        else:
+            sql_filter = f"SELECT * FROM {{table_name}} LIMIT {sample_size}"
+            filters = None
+
+        try:
+            resampled_df = resample_from_db(
+                display_id=metadata[settings.MEDIA_TYPE]["display_id"],
+                sql_filter=sql_filter,
+                filters=filters,
+                limit=sample_size,
+                ipython_shell=get_ipython,
+            )
+        except Exception as e:
+            assert False, f"Resample failed with error: {e}"
+
+        # we should never end up with more rows than the original dataframe,
+        # but we may get fewer rows depending on the filters applied
+        assert resampled_df.shape[0] <= sample_random_dataframe.shape[0]
+        # we should never end up with more columns than the original dataframe
+        assert resampled_df.shape[1] == sample_random_dataframe.shape[1]


### PR DESCRIPTION
After a resampling, the `.index_name` of DXDataFrame was not capturing the default index name to be used to `.set_index()` back to its original pre-database structure. This fixes the issue by assigning `index_name` to `index` if no custom index or multiindex is used, so when `.reset_index()` is called before registering to duckdb, the `index` column will be available in any rows returned from a database query.

Also adding some extra tests to make sure things like this don't crop up again.