### PR TITLE
Fixes #51 - handle groupby pd.Series objects with `.name` & `.index.names` conflict

### DIFF
--- a/src/dx/utils/datatypes.py
+++ b/src/dx/utils/datatypes.py
@@ -318,6 +318,70 @@ def to_dataframe(obj) -> pd.DataFrame:
     Converts an object to a pandas dataframe.
     """
     logger.debug(f"converting {type(obj)} to pd.DataFrame")
-    # TODO: support custom converters
+
+    # handling for groupby operations returning pd.Series
+    index_reset_name = None
+    if is_groupby_series(obj):
+        orig_index_names = obj.index.names
+        index_reset_name = groupby_series_index_name(obj.index)
+        # this will convert a MultiIndex series to a flat DataFrame
+        obj = obj.reset_index(name=index_reset_name)
+        # ensure we keep the original index structure
+        obj.set_index(orig_index_names, inplace=True)
+
     df = pd.DataFrame(obj)
     return df
+
+
+def is_groupby_series(s: pd.Series) -> bool:
+    """
+    Checks if the pd.Series is the result of a groupby operation
+    by checking if the index is a MultiIndex and its name is
+    also used as a level in its index.
+
+    Example:
+
+    df = pd.DataFrame({
+        'foo': list('aaabbcddee'),
+        'bar': np.random.rand(1, 10)[0],
+        'baz': np.random.randint(-10, 10, 10)
+    })
+
+    group = df.groupby('foo').bar.value_counts()
+    print(group)
+    >>> foo  bar
+    a    0.304653    1
+         0.440604    1
+         0.445702    1
+    b    0.164294    1
+         0.296721    1
+    c    0.789996    1
+    d    0.550120    1
+         0.948220    1
+    e    0.223248    1
+         0.664756    1
+    Name: bar, dtype: int64
+
+    print(group.index.names)
+    >>> ['foo', 'bar']
+
+    print(group.name)
+    >>> bar
+    """
+    if not isinstance(s, pd.Series):
+        return False
+    if not isinstance(s.index, pd.MultiIndex):
+        return False
+    return s.name in s.index.names
+
+
+def groupby_series_index_name(index: pd.MultiIndex) -> str:
+    """
+    Creates a name for groupby operations to provide using a .reset_index()
+    based on the dataframe's MultiIndex names.
+
+    Example:
+    - A MultiIndex with level names of ["foo", "bar"] will return "foo.bar.value"
+    """
+    index_trail = ".".join([str(name) for name in index.names])
+    return f"{index_trail}.value"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,24 @@ def sample_groupby_dataframe(sample_random_dataframe: pd.DataFrame) -> pd.DataFr
 
 
 @pytest.fixture
+def sample_groupby_series(sample_random_dataframe: pd.DataFrame) -> pd.DataFrame:
+    """
+    This will generate a pd.Series with a MultiIndex and one column whose name also appears in the MultiIndex names.
+    """
+    return sample_random_dataframe.groupby(
+        ["keyword_column", "integer_column"]
+    ).float_column.value_counts()
+
+
+@pytest.fixture
+def sample_multiindex_series(sample_random_dataframe: pd.DataFrame) -> pd.DataFrame:
+    """
+    This will generate a pd.Series with a MultiIndex and one column whose name does not appear in the MultiIndex names.
+    """
+    return sample_random_dataframe.groupby(["keyword_column", "integer_column"]).float_column.mean()
+
+
+@pytest.fixture
 def sample_large_dataframe() -> pd.DataFrame:
     """
     Generates a dataframe that is within the MAX_ROWS/MAX_COLUMNS limits,

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -206,6 +206,38 @@ class TestMultiIndexDataFrames:
         except Exception as e:
             assert False, f"{e}"
 
+    def test_simple_succeeds_with_groupby_series(
+        self,
+        sample_groupby_series: pd.Series,
+        get_ipython: TerminalInteractiveShell,
+    ):
+        """
+        Test "simple" display mode formatting doesn't fail while
+        formatting a pd.Series with a MultiIndex created from
+        a groupby operation on a single column.
+        """
+        try:
+            with settings_context(display_mode="simple"):
+                handle_format(sample_groupby_series, ipython_shell=get_ipython)
+        except Exception as e:
+            assert False, f"{e}"
+
+    def test_enhanced_succeeds_with_groupby_series(
+        self,
+        sample_groupby_series: pd.Series,
+        get_ipython: TerminalInteractiveShell,
+    ):
+        """
+        Test "enhanced" display mode formatting doesn't fail while
+        formatting a pd.Series with a MultiIndex created from
+        a groupby operation on a single column.
+        """
+        try:
+            with settings_context(display_mode="enhanced"):
+                handle_format(sample_groupby_series, ipython_shell=get_ipython)
+        except Exception as e:
+            assert False, f"{e}"
+
 
 class TestRenderableTypes:
     @pytest.mark.parametrize("renderable_type", [np.ndarray, pd.Series])


### PR DESCRIPTION
During conversion of original renderable objects to `pd.DataFrame`, this checks to see if we're dealing with a `pd.Series` with a MultiIndex `.index` whose `.name` is also found in the `.index.names`. This prevents clean calls to `.reset_index()` since the original `name` is already found. 

![image](https://user-images.githubusercontent.com/7707189/192870664-7367dae8-bd72-43ef-8309-d82cdf41d83f.png)
![image](https://user-images.githubusercontent.com/7707189/192871056-3e9519fa-11ab-46ff-bb52-b84b13969e02.png)

The new behavior will create a new `name` to provide during a `.reset_index()` call instead of casting directly to a `pd.DataFrame` by joining the MultiIndex `.names` and appending `.value`:
![image](https://user-images.githubusercontent.com/7707189/192872561-3465b230-3366-45c6-9c30-ce14bee0f685.png)

If `pd.Series` isn't included in the `RENDERABLE_OBJECTS` setting, this wouldn't be a big deal, but if we want to handle converting `pd.Series` objects to be used with the DEX supported media types, resetting and tracking the index is necessary.
