### PR TITLE
Fixes #67 - deconflict index/column names

### DIFF
--- a/src/dx/sampling.py
+++ b/src/dx/sampling.py
@@ -210,7 +210,7 @@ def get_df_dimensions(df: pd.DataFrame, prefix: Optional[str] = None) -> dict:
 
     num_rows, num_cols = df.shape
     return {
-        f"{prefix}size_bytes": df.memory_usage(deep=True).sum(),
+        f"{prefix}size_bytes": df.memory_usage().sum(),
         f"{prefix}num_rows": num_rows,
         f"{prefix}num_cols": num_cols,
     }

--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -192,5 +192,5 @@ def deconflict_index_and_column_names(df: pd.DataFrame) -> pd.DataFrame:
         return df
 
     logger.debug(f"handling columns found in index names: {intersecting_names}")
-    column_renames = {column: f'{column}.value' for column in intersecting_names}
+    column_renames = {column: f"{column}.value" for column in intersecting_names}
     return df.rename(columns=column_renames)

--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -36,6 +36,7 @@ def normalize_index_and_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     display_df = normalize_index(display_df)
     display_df = normalize_columns(display_df)
+    display_df = deconflict_index_and_column_names(display_df)
 
     return display_df
 
@@ -174,3 +175,22 @@ def generate_metadata(display_id: str, default_index_used: bool = True, **datafr
     }
     logger.debug(f"{metadata=}")
     return metadata
+
+
+def deconflict_index_and_column_names(df: pd.DataFrame) -> pd.DataFrame:
+    # we may encounter dataframes that contain the same
+    # column and index name(s), which will cause problems
+    # during .reset_index() later, so we need to rename
+    # the columns to keep the index structure the same
+    index_names = set([df.index.name])
+    if isinstance(df.index, pd.MultiIndex):
+        index_names = set(df.index.names)
+
+    column_names = set(df.columns)
+    intersecting_names = column_names.intersection(index_names)
+    if not intersecting_names:
+        return df
+
+    logger.debug(f"handling columns found in index names: {intersecting_names}")
+    column_renames = {column: f'{column}.value' for column in intersecting_names}
+    return df.rename(columns=column_renames)

--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -7,22 +7,6 @@ from dx.utils import datatypes, date_time, geometry
 logger = structlog.get_logger(__name__)
 
 
-def human_readable_size(size_bytes: int) -> str:
-    """
-    Converts bytes to a more human-readable string.
-
-    >>> human_readable_size(1689445298)
-    '1.5 GiB'
-    """
-    size_str = ""
-    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
-        if abs(size_bytes) < 1024.0:
-            size_str = f"{size_bytes:3.1f} {unit}"
-            break
-        size_bytes /= 1024.0
-    return size_str
-
-
 def is_default_index(index: pd.Index) -> bool:
     """
     Returns True if the index have no specified name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,18 @@ def sample_groupby_dataframe(sample_random_dataframe: pd.DataFrame) -> pd.DataFr
 
 
 @pytest.fixture
+def sample_resampled_dataframe(sample_random_dataframe: pd.DataFrame) -> pd.DataFrame:
+    return sample_random_dataframe.resample("1D", on="datetime_column").min()
+
+
+@pytest.fixture
+def sample_resampled_groupby_dataframe(sample_random_dataframe: pd.DataFrame) -> pd.DataFrame:
+    return (
+        sample_random_dataframe.groupby("keyword_column").resample("1D", on="datetime_column").min()
+    )
+
+
+@pytest.fixture
 def sample_groupby_series(sample_random_dataframe: pd.DataFrame) -> pd.DataFrame:
     """
     This will generate a pd.Series with a MultiIndex and one column whose name also appears in the MultiIndex names.

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -325,7 +325,9 @@ class TestIndexColumnNormalizing:
     def test_sample_resampled_groupby_dataframe(self, sample_random_dataframe: pd.DataFrame):
         """
         Test that a resampled groupby dataframe will keep its original index,
-        but the
+        but if the dataframe has a MultiIndex with names that conflict with
+        the dataframe columns, the duplicate columns will have `.value` appended
+        so .reset_index() doesn't break.
         """
         # same as the `sample_resampled_groupby_dataframe` fixture,
         # but defining the columns here makes for easier readability

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -226,7 +226,7 @@ class TestDataFrameHandling:
     ):
         """
         Test that various operations applied to dataframes will still
-        be rendered without error across the different display modes
+        be formatted without error across the different display modes
         and with datalink enabled/disabled.
         """
         if data_structure == "sample_dataframe":

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -325,9 +325,9 @@ class TestIndexColumnNormalizing:
     def test_sample_resampled_groupby_dataframe(self, sample_random_dataframe: pd.DataFrame):
         """
         Test that a resampled groupby dataframe will keep its original index,
-        but if the dataframe has a MultiIndex with names that conflict with
-        the dataframe columns, the duplicate columns will have `.value` appended
-        so .reset_index() doesn't break.
+        but if the dataframe has a MultiIndex with a name that conflicts with
+        one of the dataframe columns, the duplicate column will have `.value`
+        appended so .reset_index() doesn't break.
         """
         # same as the `sample_resampled_groupby_dataframe` fixture,
         # but defining the columns here makes for easier readability
@@ -341,3 +341,27 @@ class TestIndexColumnNormalizing:
         assert clean_df.index.equals(sample_resampled_groupby_dataframe.index)
         assert "keyword_column" not in clean_df.columns
         assert "keyword_column.value" in clean_df.columns
+
+    def test_sample_resampled_multi_groupby_dataframe(self, sample_random_dataframe: pd.DataFrame):
+        """
+        Test that a resampled groupby dataframe will keep its original index,
+        but if the dataframe has a MultiIndex with names that conflict with
+        the dataframe columns, the duplicate columns will have `.value` appended
+        so .reset_index() doesn't break.
+        """
+        # same as the `sample_resampled_groupby_dataframe` fixture,
+        # but defining the columns here makes for easier readability
+        sample_resampled_groupby_dataframe = (
+            sample_random_dataframe.groupby(["keyword_column", "integer_column"])
+            .resample("1D", on="datetime_column")
+            .min()
+        )
+        # this will add `keyword_column`, `integer_column`, and `datetime_column`
+        # as levels in the .index, but `keyword_column` and `integer_column`
+        # will remain in the .columns
+        clean_df = normalize_index_and_columns(sample_resampled_groupby_dataframe)
+        assert clean_df.index.equals(sample_resampled_groupby_dataframe.index)
+        assert "keyword_column" not in clean_df.columns
+        assert "keyword_column.value" in clean_df.columns
+        assert "integer_column" not in clean_df.columns
+        assert "integer_column.value" in clean_df.columns


### PR DESCRIPTION
- adds deconfliction function to handle instances where a column name is also found in the index names, to ultimately rename the column as `{column}.value` rather than remove it
- consolidates testing for different dataframe column/index structures

Before:
![image](https://user-images.githubusercontent.com/7707189/195463435-e1510e64-12b3-4f81-baef-d3a5a23538dc.png)

After:
![image](https://user-images.githubusercontent.com/7707189/195463331-7a417d3a-fdcf-4a88-af36-cf7c7a3bce42.png)

