### PR TITLE
Add site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,10 @@
 # general mkdocs config
+
+# Project information
 site_name: DX
+site_url: https://noteable-io.github.io/dx/
+site_author: Noteable
+
 nav:
   - Home: index.md
   - "Using with DEX":


### PR DESCRIPTION
site_url and repo_url differ. Let's set the `site_url` to the documentation url.