### PR TITLE
add handler for `datetime.timezone`-aware datetime values

### DIFF
--- a/src/dx/datatypes/date_time.py
+++ b/src/dx/datatypes/date_time.py
@@ -168,3 +168,19 @@ def handle_date_series(s: pd.Series) -> pd.Series:
         )
         s = pd.to_datetime(s)
     return s
+
+
+def handle_datetime_series(s: pd.Series) -> pd.Series:
+    utc = None
+    if str(s.dtype).startswith("datetime64[ns, "):
+        # convert all values to tz-aware and cast tz-naive values to UTC
+        # if any tz information is passed at all
+        utc = True
+
+    types = (datetime.datetime, np.datetime64)
+    if any(isinstance(v, types) for v in s.dropna().head().values):
+        logger.debug(
+            f"series `{s.name}` has datetime.datetime values; converting with pd.to_datetime()"
+        )
+        s = pd.to_datetime(s, utc=utc)
+    return s

--- a/src/dx/datatypes/main.py
+++ b/src/dx/datatypes/main.py
@@ -16,6 +16,7 @@ DX_DATATYPES = {
     "bool_column": True,
     "decimal_column": False,
     "datetime_column": True,
+    "datetimetz_column": False,
     "date_column": False,
     "time_column": False,
     "time_delta_column": False,
@@ -72,6 +73,7 @@ def random_dataframe(
     bool_column: bool = True,
     decimal_column: bool = False,
     datetime_column: bool = True,
+    datetimetz_column: bool = False,
     date_column: bool = False,
     time_column: bool = False,
     time_delta_column: bool = False,
@@ -112,6 +114,8 @@ def random_dataframe(
         Whether to include a column of `decimal.Decimal` values
     datetime_column : bool
         Whether to include a column of `datetime.datetime` values
+    datetimetz_column : bool
+        Whether to include a column of `datetime.datetime` values with timezones
     date_column : bool
         Whether to include a column of `datetime.date` values
     time_column : bool
@@ -175,6 +179,9 @@ def random_dataframe(
     # date/time columns
     if datetime_column:
         df["datetime_column"] = date_time.generate_datetime_series(num_rows)
+
+    if datetimetz_column:
+        df["datetimetz_column"] = date_time.generate_datetimetz_series(num_rows)
 
     if date_column:
         df["date_column"] = date_time.generate_date_series(num_rows)

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -42,24 +42,6 @@ def test_data_types_with_build_table_schema(dtype: str):
     assert isinstance(schema, dict)
 
 
-@pytest.mark.parametrize("display_mode", ["simple", "enhanced"])
-@pytest.mark.parametrize("dtype", SORTED_DX_DATATYPES)
-def test_generate_body(dtype: str, display_mode: str):
-    """
-    Test that we've correctly handled data types before building the schema and metadata for
-    the DXDisplayFormatter.
-    """
-    params = {dt: False for dt in SORTED_DX_DATATYPES}
-    params[dtype] = True
-    df = random_dataframe(**params)
-    try:
-        with settings_context(display_mode=display_mode):
-            payload = generate_body(df)
-    except Exception as e:
-        assert False, f"{dtype} failed with {e}"
-    assert isinstance(payload, dict)
-
-
 @pytest.mark.xfail(reason="only for dev")
 @pytest.mark.parametrize("dtype", SORTED_DX_DATATYPES)
 def test_hash_pandas_object(dtype: str):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -20,8 +20,6 @@ from dx.datatypes.main import (
     quick_random_dataframe,
     random_dataframe,
 )
-from dx.formatters.main import generate_body
-from dx.settings import settings_context
 from dx.utils.formatting import clean_column_values
 from dx.utils.tracking import generate_df_hash
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -215,6 +215,17 @@ class TestDatatypeHandling:
             series.values[0], (datetime, np.datetime64)
         ), f"cleaned series value is {type(series.values[0])}"
 
+    def test_datetimetz_series_converted(self):
+        series = date_time.generate_datetimetz_series(5)
+        series = clean_column_values(series)
+        assert str(series.dtype).startswith("datetime64[ns, ")
+        assert isinstance(
+            series.values[0], (datetime, np.datetime64)
+        ), f"cleaned series value is {type(series.values[0])}"
+        # this is the most important part to check;
+        # if this fails, build_table_schema() will fail
+        assert hasattr(series.dtype.tz, "zone")
+
     def test_date_series_converted(self):
         # datetime.date values are converted to pd.Timestamp
         series = date_time.generate_date_series(5)


### PR DESCRIPTION
Workaround for timezone-aware datetime values: 
- https://github.com/pandas-dev/pandas/issues/39537

Removing `test_generate_body()` since we should never get to `generate_body()` directly without going through the index/column normalization to handle various data types.