### PR TITLE
Use mkdocs-material preferred ci and use pip for docs not poetry

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -20,6 +20,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install requirements.txt
-      - run: pip install mkdocs-material 
+      - run: pip install -r requirements-docs.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -3,24 +3,23 @@ name: Publish docs
 on:
   push:
     branches:
+      - master 
       - main
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
 
 jobs:
-  publish-docs:
+  deploy:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup nox
-        uses: daisylb/setup-nox@v2.1.0
-      - name: Setup poetry
-        uses: Gr1N/setup-poetry@v7
-      - name: Install dependencies
-        run: |
-          poetry export -f requirements.txt --extras "docs" --without-hashes --with dev --output requirements.txt
-          pip install -r requirements.txt
-      - name: Publish docs
-        run: nox -s publish_docs
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install requirements.txt
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.9
       - run: pip install -r requirements-docs.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -3,7 +3,6 @@ name: Publish docs
 on:
   push:
     branches:
-      - master 
       - main
   pull_request:
     branches:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,5 @@
+mkdocs
+mkdocs-material
+mkdocs-jupyter
+mkdocstrings
+mkdocstrings-python


### PR DESCRIPTION
- Use mkdocs-material recommendation
- Simplify the ci build by using pip instead of poetry, nox, nox-poetry

@shouples: you should now see docs on PRs for example https://noteable-io.github.io/dx/plotting/dashboards/