### PR TITLE
handle duplicate columns

### DIFF
--- a/src/dx/comms/assignment.py
+++ b/src/dx/comms/assignment.py
@@ -6,6 +6,7 @@ from IPython.core.interactiveshell import InteractiveShell
 
 from dx.filtering import resample_from_db
 from dx.types.filters import DEXFilterSettings
+from dx.utils.formatting import incrementing_label
 
 logger = structlog.get_logger(__name__)
 
@@ -50,24 +51,10 @@ def handle_assignment_comm(msg: dict, ipython_shell: Optional[InteractiveShell] 
         variable_name = data["variable_name"]
 
         # if the variable already exists in the user namespace, add a suffix so the previous value isn't overwritten
-        free_variable_name = check_variable_name(variable_name, ipython=ipython)
-        logger.debug(
-            f"assigning {len(sampled_df)}-row dataframe to `{free_variable_name}` in {ipython}"
-        )
-        ipython.user_ns[free_variable_name] = sampled_df
-
-
-def check_variable_name(variable_name: str, ipython: InteractiveShell) -> str:
-    """
-    Checks if the variable name already exists in the user namespace,
-    and if so, appends a numeric suffix to it.
-    """
-    if variable_name in ipython.user_ns:
-        suffix = 1
-        while f"{variable_name}_{suffix}" in ipython.user_ns:
-            suffix += 1
-        variable_name = f"{variable_name}_{suffix}"
-    return variable_name
+        if variable_name in ipython.user_ns:
+            variable_name = incrementing_label(variable_name, ipython.user_ns)
+        logger.debug(f"assigning {len(sampled_df)}-row dataframe to `{variable_name}` in {ipython}")
+        ipython.user_ns[variable_name] = sampled_df
 
 
 def register_assignment_comm(ipython_shell: InteractiveShell) -> None:

--- a/src/dx/formatters/main.py
+++ b/src/dx/formatters/main.py
@@ -13,6 +13,7 @@ from dx.sampling import get_df_dimensions, sample_if_too_big
 from dx.settings import settings
 from dx.types.main import DXDisplayMode
 from dx.utils.formatting import (
+    check_for_duplicate_columns,
     generate_metadata,
     is_default_index,
     normalize_index_and_columns,
@@ -75,6 +76,7 @@ def handle_format(
     logger.debug(f"*** handling {settings.DISPLAY_MODE} format for {type(obj)=} ***")
     if not isinstance(obj, pd.DataFrame):
         obj = to_dataframe(obj)
+    obj = check_for_duplicate_columns(obj)
     logger.debug(f"{obj.shape=}")
 
     default_index_used = is_default_index(obj.index)

--- a/src/dx/formatters/main.py
+++ b/src/dx/formatters/main.py
@@ -101,7 +101,7 @@ def handle_format(
             extra_metadata=extra_metadata,
         )
     except Exception as e:
-        logger.exception(f"Error in datalink_processing: {e}")
+        logger.debug(f"Error in datalink_processing: {e}")
         # fall back to default processing
         payload, metadata = format_output(
             obj,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,18 @@ def sample_random_dataframe() -> pd.DataFrame:
 
 
 @pytest.fixture
+def sample_random_dataframe_with_duplicate_columns(
+    sample_random_dataframe: pd.DataFrame,
+) -> pd.DataFrame:
+    return sample_random_dataframe.rename(
+        columns={
+            "integer_column": "number_column",
+            "float_column": "number_column",
+        }
+    )
+
+
+@pytest.fixture
 def sample_cleaned_random_dataframe(sample_random_dataframe: pd.DataFrame) -> pd.DataFrame:
     return normalize_index_and_columns(sample_random_dataframe)
 


### PR DESCRIPTION
Since pandas is typically more lenient with duplicate column labels, but appends `_x`/`_y` to column names after joins, it made sense to add similar functionality to `dx` formatting dataframe objects with duplicate column labels.

This will now iterate over every duplicate column found in a dataframe (by columnar index position) and append with an incrementing numeric suffix. 

![image](https://user-images.githubusercontent.com/7707189/207736806-3406f0ac-0971-4b56-9ea9-9058f6255a6f.png)
![image](https://user-images.githubusercontent.com/7707189/207736823-7321aec4-ee4d-43f8-93c1-4348f56c08a4.png)
