### PR TITLE
fix programmatic chart/dashboard functions

### DIFF
--- a/docs/_charts/dashboards.md
+++ b/docs/_charts/dashboards.md
@@ -1,15 +1,15 @@
 <!-- --8<-- [start:usage] -->
 Just like the [plotting](../../../plotting/overview/#plotting) functions, generating dashboards with `dx` is **very** experimental and prone to change.
-## [Making a Dashboard](../../reference/charts/basic_charts/#src.dx.plotting.dashboards.make_dashboard)
-If you create charts using `dx` functions, you may want to combine them into a single view or **dashboard**. This can be done with `make_dashboard()`.
+## [Making a Dashboard](../../reference/charts/basic_charts/#src.dx.plotting.dashboards.dashboard)
+If you create charts using `dx` functions, you may want to combine them into a single view or **dashboard**. This can be done with `dashboard()`.
 
-Similar to the chart functions, `make_dashboard()` mainly requires a pandas DataFrame, as well as a list of views in a matrix-like orientation. (Each item in the list is treated as a row, and each row can be a list of views to specify column positioning.) 
+Similar to the chart functions, `dashboard()` mainly requires a pandas DataFrame, as well as a list of views in a matrix-like orientation. (Each item in the list is treated as a row, and each row can be a list of views to specify column positioning.) 
 
 ### Simple
 Here's a quick example where we make a dashboard using two rows -- the top row will have [scatter](../../../plotting/basic_charts/#scatter) and [bar](../../../plotting/basic_charts/#bar) charts, and the bottom will be our default grid view:
 
 ```python
-dx.make_dashboard(
+dx.dashboard(
     df,
     views=[
         ['scatter', 'bar'],
@@ -33,7 +33,7 @@ custom_dotplot = {
     }
 }
 
-dx.make_dashboard(
+dx.dashboard(
     df,
     views=[
         [custom_dotplot, 'force_directed_network'],
@@ -47,5 +47,5 @@ dx.make_dashboard(
 
 <!-- --8<-- [start:ref] -->
 ## [Making a Dashboard](../../../plotting/overview/#making_a_dashboard)
-::: src.dx.plotting.dashboards.make_dashboard
+::: src.dx.plotting.dashboards.dashboard
 <!-- --8<-- [end:ref] -->

--- a/src/dx/plotting/dashboards.py
+++ b/src/dx/plotting/dashboards.py
@@ -5,12 +5,13 @@ import structlog
 
 from dx.formatters.main import handle_format
 from dx.plotting.dex import _samples
+from dx.settings import settings_context
 from dx.types.dex_metadata import DEXMetadata, DEXView
 
 logger = structlog.get_logger(__name__)
 
 
-def make_dashboard(
+def dashboard(
     df: pd.DataFrame,
     views: List[Union[str, dict, list, DEXView]],
     **kwargs,
@@ -88,14 +89,15 @@ def make_dashboard(
 
     dex_dashboard_metadata = DEXView.parse_obj(dashboard_view_metadata)
 
-    handle_format(
-        df,
-        extra_metadata={
-            "dashboard": {
-                "multiViews": [
-                    dex_dashboard_metadata.dict(by_alias=True),
-                ],
+    with settings_context(generate_dex_metadata=True):
+        handle_format(
+            df,
+            extra_metadata={
+                "dashboard": {
+                    "multiViews": [
+                        dex_dashboard_metadata.dict(by_alias=True),
+                    ],
+                },
+                "views": dex_metadata.views,
             },
-            "views": dex_metadata.views,
-        },
-    )
+        )

--- a/src/dx/plotting/dex/_samples.py
+++ b/src/dx/plotting/dex/_samples.py
@@ -5,6 +5,7 @@ Convenience functions to quickly create charts from a dataframe with no required
 from typing import Optional
 
 from dx.formatters.main import handle_format
+from dx.settings import settings_context
 from dx.types.dex_metadata import DEXView
 
 
@@ -24,10 +25,12 @@ def sample_chart(
         sample_chart_metadata["chart"] = chart
     if return_view:
         return DEXView.parse_obj(sample_chart_metadata)
-    handle_format(
-        df,
-        extra_metadata=sample_chart_metadata,
-    )
+
+    with settings_context(generate_dex_metadata=True):
+        handle_format(
+            df,
+            extra_metadata=sample_chart_metadata,
+        )
 
 
 # ⛔

--- a/src/dx/plotting/main.py
+++ b/src/dx/plotting/main.py
@@ -47,9 +47,9 @@ def plot(df: dict, kind: str, **kwargs) -> None:
     elif (sample_chart := getattr(_samples, f"sample_{kind}", None)) is not None:
         view = sample_chart(df, return_view=True, **kwargs)
     elif kind == "dashboard":
-        from dx.plotting.dashboards import make_dashboard
+        from dx.plotting.dashboards import dashboard
 
-        return make_dashboard(df, **kwargs)
+        return dashboard(df, **kwargs)
     else:
         raise NotImplementedError(f"{kind=} not yet supported for plotting.backend='dx'")
 
@@ -101,10 +101,8 @@ def handle_view(
         by_alias=True,
     )
     logger.debug(f"{view_metadata=}")
-    handle_format(
-        df,
-        extra_metadata=view_metadata,
-    )
+    with settings_context(generate_dex_metadata=True):
+        handle_format(df, extra_metadata=view_metadata)
 
 
 def raise_for_missing_columns(columns: List[str], existing_columns: pd.Index) -> None:


### PR DESCRIPTION
Adds `settings_context()` to enable `GENERATE_DEX_METADATA` when calling the chart/dashboard convenience functions.

Previously, if `GENERATE_DEX_METADATA` was disabled altogether, these functions would return the default metadata since only the dx plotting backend for pandas was using the settings context.


Also renames `make_dashboard()` to just `dashboard()`.