### PR TITLE
ensure `applied_filters` items are dictionaries

### DIFF
--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -309,7 +309,8 @@ def generate_metadata(
             dataframe_info = parent_dataframe_info
         # these are set whenever store_sample_to_history() is called after a filter action from the frontend
         sample_history = existing_metadata.get("datalink", {}).get("sample_history", [])
-        filters = parent_dxdf.filters
+        # we shouldn't have a mix of pydantic FilterTypes and dicts here, but just in case
+        filters = [f.dict() if not isinstance(f, dict) else f for f in parent_dxdf.filters]
 
     metadata = {
         "datalink": {

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -39,9 +39,22 @@ def test_store_sample_to_history(
     )
 
     datalink_metadata = sample_dxdataframe.metadata["datalink"]
+
     assert datalink_metadata["applied_filters"] == filters
     if has_filters:
-        assert isinstance(datalink_metadata["applied_filters"][0], dict)
+        # ensure sampling history and currently applied filters are present
+        # and properly formatted for the frontend to reference
+        applied_filters = datalink_metadata["applied_filters"]
+        assert isinstance(applied_filters[0], dict)
+
+        sample_history = datalink_metadata["sample_history"]
+        assert len(sample_history) == 1
+        assert "filters" in sample_history[0]
+        assert isinstance(sample_history[0]["filters"], list)
+        assert isinstance(sample_history[0]["filters"][0], dict)
+        assert sample_history[0]["filters"][0] == filters[0]
+        assert sample_history[0]["sampling_time"] is not None
+
     assert datalink_metadata["sampling_time"] is not None
 
     assert datalink_metadata["dataframe_info"]["orig_num_rows"] == sample_dxdataframe.df.shape[0]

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -38,17 +38,14 @@ def test_store_sample_to_history(
         filters,
     )
 
-    assert sample_dxdataframe.metadata["datalink"]["applied_filters"] == filters
-    assert sample_dxdataframe.metadata["datalink"]["sampling_time"] is not None
+    datalink_metadata = sample_dxdataframe.metadata["datalink"]
+    assert datalink_metadata["applied_filters"] == filters
+    if has_filters:
+        assert isinstance(datalink_metadata["applied_filters"][0], dict)
+    assert datalink_metadata["sampling_time"] is not None
 
-    assert (
-        sample_dxdataframe.metadata["datalink"]["dataframe_info"]["orig_num_rows"]
-        == sample_dxdataframe.df.shape[0]
-    )
-    assert (
-        sample_dxdataframe.metadata["datalink"]["dataframe_info"]["orig_num_cols"]
-        == sample_dxdataframe.df.shape[1]
-    )
+    assert datalink_metadata["dataframe_info"]["orig_num_rows"] == sample_dxdataframe.df.shape[0]
+    assert datalink_metadata["dataframe_info"]["orig_num_cols"] == sample_dxdataframe.df.shape[1]
 
 
 class TestResample:
@@ -258,6 +255,10 @@ class TestResample:
                 resampled_dxdf.display_id
                 == SUBSET_HASH_TO_PARENT_DATA[resampled_dxdf.hash]["display_id"]
             )
+
+            if has_filters:
+                applied_filter = resampled_dxdf.metadata["datalink"]["applied_filters"][0]
+                assert isinstance(applied_filter, dict)
 
     @pytest.mark.parametrize("has_filters", [True, False])
     @pytest.mark.parametrize("display_mode", ["simple", "enhanced"])


### PR DESCRIPTION
During a resample action, when parsing the parent `DXDataFrame` metadata, any existing filters are cast to `FilterTypes`. When this is applied to the display metadata, the pydantic models are converted to lists of lists instead of lists of dictionaries. This change makes the conversion explicit within `generate_metadata()` to ensure inherited filters from the parent `DXDataFrame` are the correct type.