### PR TITLE
add character limits on `object` columns with `settings.MAX_STRING_LENGTH`

### DIFF
--- a/src/dx/formatters/enhanced.py
+++ b/src/dx/formatters/enhanced.py
@@ -12,6 +12,7 @@ from dx.settings import settings  # noqa
 class DXSettings(BaseSettings):
     DX_DISPLAY_MAX_ROWS: int = 50_000
     DX_DISPLAY_MAX_COLUMNS: int = 50
+    DX_MAX_STRING_LENGTH: int = 50
     DX_HTML_TABLE_SCHEMA: bool = Field(True, allow_mutation=False)
     DX_MEDIA_TYPE: str = Field("application/vnd.dex.v1+json", allow_mutation=False)
 
@@ -47,6 +48,7 @@ def register(ipython_shell: Optional[InteractiveShell] = None) -> None:
     settings_to_apply = {
         "DISPLAY_MAX_COLUMNS",
         "DISPLAY_MAX_ROWS",
+        "MAX_STRING_LENGTH",
         "MEDIA_TYPE",
         "FLATTEN_INDEX_VALUES",
         "FLATTEN_COLUMN_VALUES",

--- a/src/dx/formatters/plain.py
+++ b/src/dx/formatters/plain.py
@@ -21,6 +21,7 @@ class PandasSettings(BaseSettings):
     # "plain" (pandas) display mode
     PANDAS_DISPLAY_MAX_ROWS: int = 60
     PANDAS_DISPLAY_MAX_COLUMNS: int = 20
+    PANDAS_MAX_STRING_LENGTH: int = 50
     PANDAS_HTML_TABLE_SCHEMA: bool = Field(False, allow_mutation=False)
     PANDAS_MEDIA_TYPE: str = Field("application/vnd.dataresource+json", allow_mutation=False)
 
@@ -54,6 +55,7 @@ def reset(ipython_shell: Optional[InteractiveShell] = None) -> None:
 
     pd.set_option("display.max_columns", pandas_settings.PANDAS_DISPLAY_MAX_COLUMNS)
     pd.set_option("display.max_rows", pandas_settings.PANDAS_DISPLAY_MAX_ROWS)
+    pd.set_option("display.max_colwidth", pandas_settings.PANDAS_MAX_STRING_LENGTH)
 
     ipython = ipython_shell or get_ipython()
     ipython.display_formatter = DEFAULT_IPYTHON_DISPLAY_FORMATTER

--- a/src/dx/formatters/simple.py
+++ b/src/dx/formatters/simple.py
@@ -13,6 +13,7 @@ class DataResourceSettings(BaseSettings):
     # "simple" (classic simpleTable/DEX) display mode
     DATARESOURCE_DISPLAY_MAX_ROWS: int = 50_000
     DATARESOURCE_DISPLAY_MAX_COLUMNS: int = 50
+    DATARESOURCE_MAX_STRING_LENGTH: int = 50
     DATARESOURCE_HTML_TABLE_SCHEMA: bool = Field(True, allow_mutation=False)
     DATARESOURCE_MEDIA_TYPE: str = Field("application/vnd.dataresource+json", allow_mutation=False)
 
@@ -49,6 +50,7 @@ def deregister(ipython_shell: Optional[InteractiveShell] = None) -> None:
     settings_to_apply = {
         "DISPLAY_MAX_COLUMNS",
         "DISPLAY_MAX_ROWS",
+        "MAX_STRING_LENGTH",
         "MEDIA_TYPE",
         "FLATTEN_INDEX_VALUES",
         "FLATTEN_COLUMN_VALUES",

--- a/src/dx/sampling.py
+++ b/src/dx/sampling.py
@@ -35,7 +35,7 @@ def sample_if_too_big(df: pd.DataFrame, display_id: Optional[str] = None) -> pd.
     max_chars = settings.MAX_STRING_LENGTH
     string_columns = df.select_dtypes(include="object").columns
     for col in string_columns:
-        df[col] = df[col].str[:max_chars]
+        df[col] = df[col].apply(lambda x: x[:max_chars] if isinstance(x, str) else x)
 
     # in the event that there are nested/large values bloating the dataframe,
     # easiest to reduce rows even further here

--- a/src/dx/sampling.py
+++ b/src/dx/sampling.py
@@ -32,7 +32,7 @@ def sample_if_too_big(df: pd.DataFrame, display_id: Optional[str] = None) -> pd.
         df = sample_rows(df, num_rows=max_rows, display_id=display_id)
 
     # check any `object` rows and truncate based on character limits
-    max_chars = settings.STRING_CHARACTER_LIMIT
+    max_chars = settings.MAX_STRING_LENGTH
     string_columns = df.select_dtypes(include="object").columns
     for col in string_columns:
         df[col] = df[col].str[:max_chars]

--- a/src/dx/sampling.py
+++ b/src/dx/sampling.py
@@ -31,6 +31,12 @@ def sample_if_too_big(df: pd.DataFrame, display_id: Optional[str] = None) -> pd.
     if df_too_long:
         df = sample_rows(df, num_rows=max_rows, display_id=display_id)
 
+    # check any `object` rows and truncate based on character limits
+    max_chars = settings.STRING_CHARACTER_LIMIT
+    string_columns = df.select_dtypes(include="object").columns
+    for col in string_columns:
+        df[col] = df[col].str[:max_chars]
+
     # in the event that there are nested/large values bloating the dataframe,
     # easiest to reduce rows even further here
     max_size_bytes = settings.MAX_RENDER_SIZE_BYTES

--- a/src/dx/settings.py
+++ b/src/dx/settings.py
@@ -124,6 +124,13 @@ class Settings(BaseSettings):
         pd.set_option("html.table_schema", val)
         return val
 
+    @validator("MAX_STRING_LENGTH", pre=True, always=True)
+    def validate_max_string_length(cls, val):
+        if val < 0:
+            raise ValueError("MAX_STRING_LENGTH must be >= 0")
+        pd.set_option("display.max_colwidth", val)
+        return val
+
     class Config:
         validate_assignment = True
         use_enum_values = True

--- a/src/dx/settings.py
+++ b/src/dx/settings.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
     MEDIA_TYPE: str = "application/vnd.dataresource+json"
 
     MAX_RENDER_SIZE_BYTES: int = 100 * MB
-    MAX_STRING_LENGTH: int = 1000
+    MAX_STRING_LENGTH: int = 100
 
     RENDERABLE_OBJECTS: Set[type] = get_default_renderable_types()
 

--- a/src/dx/settings.py
+++ b/src/dx/settings.py
@@ -46,6 +46,8 @@ class Settings(BaseSettings):
     MEDIA_TYPE: str = "application/vnd.dataresource+json"
 
     MAX_RENDER_SIZE_BYTES: int = 100 * MB
+    MAX_STRING_LENGTH: int = 1000
+
     RENDERABLE_OBJECTS: Set[type] = get_default_renderable_types()
 
     # what percentage of the dataset to remove during each sampling
@@ -79,8 +81,6 @@ class Settings(BaseSettings):
 
     GENERATE_DEX_METADATA: bool = False
     ALLOW_NOTEABLE_ATTRS: bool = True
-
-    STRING_CHARACTER_LIMIT: int = 1000
 
     @validator("RENDERABLE_OBJECTS", pre=True, always=True)
     def validate_renderables(cls, vals):

--- a/src/dx/settings.py
+++ b/src/dx/settings.py
@@ -80,6 +80,8 @@ class Settings(BaseSettings):
     GENERATE_DEX_METADATA: bool = False
     ALLOW_NOTEABLE_ATTRS: bool = True
 
+    STRING_CHARACTER_LIMIT: int = 1000
+
     @validator("RENDERABLE_OBJECTS", pre=True, always=True)
     def validate_renderables(cls, vals):
         """Allow passing comma-separated strings or actual types."""

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -90,3 +90,29 @@ def test_long_wide_dataframe_is_reduced_from_both_dimensions(
     assert reduced_width <= settings.DISPLAY_MAX_COLUMNS
     assert reduced_length < orig_length
     assert reduced_length <= settings.DISPLAY_MAX_ROWS
+
+
+def test_big_value_dataframe_is_character_limited():
+    """
+    Test that a dataframe with large string values will be truncated
+    based on the display mode's MAX_STRING_LENGTH setting.
+    """
+    df = pd.DataFrame(
+        {
+            "foo": [
+                "a" * 1,
+                "b" * 10,
+                "c" * 100,
+                "d" * 1000,
+                "e" * 10000,
+                "f" * 100000,
+            ]
+        }
+    )
+    orig_column = df["foo"].copy()
+    sampled_df = sample_if_too_big(df)
+    sampled_df["foo_length"] = sampled_df["foo"].apply(len)
+    # if settings.MAX_STRING_LENGTH is set to 1000, then the rows with greater
+    # than 1000 characters will be truncated to up to 1000 characters
+    assert (sampled_df["foo_length"] <= settings.MAX_STRING_LENGTH).all()
+    assert not sampled_df["foo"].equals(orig_column)


### PR DESCRIPTION
Previously, large string values would result in truncating by stripping off rows until the size of the dataframe in memory was at/below `MAX_RENDER_SIZE_BYTES`. This truncates larger string values (less aggressive) before removing rows (more aggressive) to allow more data to be sent to the frontend overall.

Adds `MAX_STRING_LENGTH` based on pandas default `display.max_colwidth` and enforces a cap at that limit after truncating by row/column limits _before_ reducing the overall render size of the dataframe further by removing rows. In doing so, the `datalink.dataframe_info.truncated_string_columns` metadata will provide a list of string columns that were shortened.