### PR TITLE
adjust `MAX_STRING_LENGTH`

### DIFF
--- a/src/dx/formatters/enhanced.py
+++ b/src/dx/formatters/enhanced.py
@@ -12,7 +12,7 @@ from dx.settings import settings  # noqa
 class DXSettings(BaseSettings):
     DX_DISPLAY_MAX_ROWS: int = 50_000
     DX_DISPLAY_MAX_COLUMNS: int = 50
-    DX_MAX_STRING_LENGTH: int = 50
+    DX_MAX_STRING_LENGTH: int = 250
     DX_HTML_TABLE_SCHEMA: bool = Field(True, allow_mutation=False)
     DX_MEDIA_TYPE: str = Field("application/vnd.dex.v1+json", allow_mutation=False)
 

--- a/src/dx/formatters/main.py
+++ b/src/dx/formatters/main.py
@@ -181,6 +181,9 @@ def format_output(
     # based on settings.MAX_STRING_LENGTH for the frontend to provide an affordance
     truncated_string_columns = []
     for col, orig_length in orig_col_string_lengths.items():
+        if col not in sampled_col_string_lengths:
+            # original column may have been removed during truncating
+            continue
         if orig_length > sampled_col_string_lengths[col]:
             truncated_string_columns.append(col)
 

--- a/src/dx/formatters/simple.py
+++ b/src/dx/formatters/simple.py
@@ -13,7 +13,7 @@ class DataResourceSettings(BaseSettings):
     # "simple" (classic simpleTable/DEX) display mode
     DATARESOURCE_DISPLAY_MAX_ROWS: int = 50_000
     DATARESOURCE_DISPLAY_MAX_COLUMNS: int = 50
-    DATARESOURCE_MAX_STRING_LENGTH: int = 50
+    DATARESOURCE_MAX_STRING_LENGTH: int = 250
     DATARESOURCE_HTML_TABLE_SCHEMA: bool = Field(True, allow_mutation=False)
     DATARESOURCE_MEDIA_TYPE: str = Field("application/vnd.dataresource+json", allow_mutation=False)
 

--- a/src/dx/settings.py
+++ b/src/dx/settings.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
     MEDIA_TYPE: str = "application/vnd.dataresource+json"
 
     MAX_RENDER_SIZE_BYTES: int = 100 * MB
-    MAX_STRING_LENGTH: int = 100
+    MAX_STRING_LENGTH: int = 50
 
     RENDERABLE_OBJECTS: Set[type] = get_default_renderable_types()
 


### PR DESCRIPTION
Increase simple/enhanced display modes' values, lower default to pandas `display.max_colwidth` default value.

Also adds a fix for checking if a string column had its values truncated if the column was removed altogether due to truncating-related settings.