### PR TITLE
provide `user_variable_name` in display metadata

### DIFF
--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -312,6 +312,15 @@ def generate_metadata(
         # we shouldn't have a mix of pydantic FilterTypes and dicts here, but just in case
         filters = [f.dict() if not isinstance(f, dict) else f for f in parent_dxdf.filters]
 
+    # TODO: wrap this up into the DXDataFrame init properties with some refactoring
+    user_variable_name = variable_name
+    if str(variable_name).startswith("unk_dataframe_") and len(variable_name) == 46:
+        # `unk_dataframe_<hash>` with dashes removed, which is what we use
+        # to reference dataframe objects not explicitly assigned to variables
+        # where we need to keep a reference to them in duckdb without relying on
+        # temporary variables in the user namespace
+        user_variable_name = None
+
     metadata = {
         "datalink": {
             "dataframe_info": dataframe_info,
@@ -327,6 +336,7 @@ def generate_metadata(
             "sample_history": sample_history,
             "sampling_time": pd.Timestamp("now").strftime(settings.DATETIME_STRING_FORMAT),
             "variable_name": variable_name,
+            "user_variable_name": user_variable_name,
         },
         "display_id": display_id,
     }

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -474,6 +474,7 @@ class TestMetadataVariableName:
             _, metadata = handle_format(sample_random_dataframe, ipython_shell=get_ipython)
             display_metadata = metadata[settings.MEDIA_TYPE]
             assert display_metadata["datalink"]["variable_name"] == "test_df"
+            assert display_metadata["datalink"]["user_variable_name"] == "test_df"
 
     @pytest.mark.parametrize("display_mode", ["simple", "enhanced"])
     def test_unassigned_variable_name_present(
@@ -492,6 +493,7 @@ class TestMetadataVariableName:
             _, metadata = handle_format(sample_random_dataframe, ipython_shell=get_ipython)
             display_metadata = metadata[settings.MEDIA_TYPE]
             assert display_metadata["datalink"]["variable_name"].startswith("unk_dataframe")
+            assert display_metadata["datalink"]["user_variable_name"] is None
 
     @pytest.mark.parametrize("display_mode", ["simple", "enhanced"])
     def test_empty_variable_name_with_datalink_disabled(


### PR DESCRIPTION
Quick hack to provide this to the frontend for now, but should be followed-up in a future PR to refactor the DXDataFrame properties and methods.