### PR TITLE
don't return private variables that match current dataframe

### DIFF
--- a/src/dx/utils/tracking.py
+++ b/src/dx/utils/tracking.py
@@ -190,11 +190,6 @@ def get_df_variable_name(
         logger.debug(f"{named_df_vars_with_same_data=}")
         return named_df_vars_with_same_data[0]
 
-    if matching_df_vars:
-        # dataframe rendered without variable assignment
-        logger.debug(f"no matching dataframe variables found: {matching_df_vars=}")
-        return matching_df_vars[-1]
-
     # no dataframe variables found, assign a new one for internal referencing
     logger.debug("no variables found matching this dataframe")
     df_uuid = f"unk_dataframe_{uuid.uuid4()}".replace("-", "")


### PR DESCRIPTION
When attempting to match a dataframe to a variable name, if the only matches were private/auto-generated variables in the user namespace (e.g. `_1`, `_2`, etc), it would return the most recent one. This would then go into `user_variable_name` in the output metadata, which had unintended side effects. This PR returns the `unk_dataframe_<hash>` temporary internal dataframe name (for duckdb registration in the kernel session) instead.

This also means any variable names starting with an underscore will be ignored and temporary variable names will be used internally instead.