### PR TITLE
handle datalink exception path & adjust timezone checks

### DIFF
--- a/src/dx/datatypes/date_time.py
+++ b/src/dx/datatypes/date_time.py
@@ -170,16 +170,6 @@ def handle_time_delta_series(s: pd.Series) -> pd.Series:
     return s
 
 
-def handle_date_series(s: pd.Series) -> pd.Series:
-    types = (datetime.date,)
-    if any(isinstance(v, types) for v in s.dropna().head().values):
-        logger.debug(
-            f"series `{s.name}` has datetime.date values; converting with pd.to_datetime()"
-        )
-        s = pd.to_datetime(s)
-    return s
-
-
 def handle_datetime_series(s: pd.Series) -> pd.Series:
     utc = None
     if str(s.dtype).startswith("datetime64[ns, "):
@@ -187,10 +177,8 @@ def handle_datetime_series(s: pd.Series) -> pd.Series:
         # if any tz information is passed at all
         utc = True
 
-    types = (datetime.datetime, np.datetime64)
+    types = (datetime.date, datetime.datetime, np.datetime64)
     if any(isinstance(v, types) for v in s.dropna().head().values):
-        logger.debug(
-            f"series `{s.name}` has datetime.datetime values; converting with pd.to_datetime()"
-        )
+        logger.debug(f"series `{s.name}` has datetime values; converting with pd.to_datetime()")
         s = pd.to_datetime(s, utc=utc)
     return s

--- a/src/dx/datatypes/date_time.py
+++ b/src/dx/datatypes/date_time.py
@@ -171,14 +171,17 @@ def handle_time_delta_series(s: pd.Series) -> pd.Series:
 
 
 def handle_datetime_series(s: pd.Series) -> pd.Series:
-    utc = None
-    if str(s.dtype).startswith("datetime64[ns, "):
-        # convert all values to tz-aware and cast tz-naive values to UTC
-        # if any tz information is passed at all
-        utc = True
-
     types = (datetime.date, datetime.datetime, np.datetime64)
-    if any(isinstance(v, types) for v in s.dropna().head().values):
-        logger.debug(f"series `{s.name}` has datetime values; converting with pd.to_datetime()")
-        s = pd.to_datetime(s, utc=utc)
+
+    sample_rows = s.dropna().head()
+    # in the event we don't have a `datetime64[ns]` dtype (i.e. `object` dtype), we need to check if
+    # any of the values have tzinfo property anyway. this might happen as a result of different
+    # datetime structures being used in the same series
+    has_tzinfo = sample_rows.apply(lambda x: hasattr(x, "tzinfo"))
+    if any(isinstance(v, types) for v in sample_rows.values):
+        logger.debug(
+            f"series `{s.name}` has datetime values; converting with pd.to_datetime()",
+            utc=has_tzinfo.any(),
+        )
+        s = pd.to_datetime(s, utc=has_tzinfo.any())
     return s

--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -184,13 +184,10 @@ def normalize_index_and_columns(df: pd.DataFrame) -> pd.DataFrame:
     Any additional formatting that needs to happen to the index,
     the columns, or the data itself should be done here.
     """
-    display_df = df.copy()
-
-    display_df = normalize_index(display_df)
-    display_df = normalize_columns(display_df)
-    display_df = deconflict_index_and_column_names(display_df)
-
-    return display_df
+    df = normalize_index(df)
+    df = normalize_columns(df)
+    df = deconflict_index_and_column_names(df)
+    return df
 
 
 def normalize_index(df: pd.DataFrame) -> pd.DataFrame:
@@ -275,7 +272,6 @@ def clean_column_values(s: pd.Series) -> pd.Series:
     """
     s = date_time.handle_time_period_series(s)
     s = date_time.handle_time_delta_series(s)
-    s = date_time.handle_date_series(s)
     s = date_time.handle_datetime_series(s)
 
     s = numeric.handle_decimal_series(s)


### PR DESCRIPTION
Handles two issues:
- When we try to clean a series that has `datetime` values but is an `object` dtype, we didn't properly catch the presence of tzinfo, which chokes the `pd.to_datetime` call inside `handle_datetime_series`.
- If we run into an issue during datalink processing (like the above), we go down the path of basic `format_output()` which was affecting the underlying dataframe in the kernel's user namespace rather than the copy of the data used for sending to the frontend. Now we're ensuring we have a copy of the dataframe set from the beginning to avoid any ambiguity in downstream processing.