### PR TITLE
clean `index` the same way we clean `columns`

### DIFF
--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -224,7 +224,7 @@ def normalize_index(df: pd.DataFrame) -> pd.DataFrame:
             df.index = pd.Index(stringify_index(df.index), name=index_name)
 
     # also ensure we clean for any unrenderable types
-    df.index = clean_series_values(df.index)
+    df.index = clean_series_values(pd.Series(df.index))
     return df
 
 

--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -224,7 +224,16 @@ def normalize_index(df: pd.DataFrame) -> pd.DataFrame:
             df.index = pd.Index(stringify_index(df.index), name=index_name)
 
     # also ensure we clean for any unrenderable types
-    df.index = clean_series_values(pd.Series(df.index))
+    if not is_multiindex:
+        clean_index = clean_series_values(pd.Series(df.index))
+        df.index = pd.Index(clean_index)
+    else:
+        clean_levels = []
+        for level in df.index.levels:
+            clean_level = clean_series_values(pd.Series(level))
+            clean_levels.append(clean_level)
+        df.index.set_levels(clean_levels, level=index_name, inplace=True)
+
     return df
 
 

--- a/src/dx/utils/formatting.py
+++ b/src/dx/utils/formatting.py
@@ -223,10 +223,10 @@ def normalize_index(df: pd.DataFrame) -> pd.DataFrame:
         else:
             df.index = pd.Index(stringify_index(df.index), name=index_name)
 
-    # also ensure we clean for any unrenderable types
+    # also ensure we clean for any unrenderable types - casting to pd.Series because various Index
+    # types don't have `.head()` methods
     if not is_multiindex:
-        clean_index = clean_series_values(pd.Series(df.index))
-        df.index = pd.Index(clean_index)
+        df.index = clean_series_values(pd.Series(df.index))
     else:
         clean_levels = []
         for level in df.index.levels:

--- a/tests/test_datatype_handling.py
+++ b/tests/test_datatype_handling.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dx.datatypes.main import SORTED_DX_DATATYPES, random_dataframe
-from dx.utils.formatting import clean_column_values
+from dx.utils.formatting import clean_series_values
 
 
 @pytest.mark.benchmark
@@ -15,7 +15,7 @@ def test_benchmark_column_cleaning(
     params[dtype] = True
     df = random_dataframe(num_rows, **params)
     for col in df.columns:
-        benchmark(clean_column_values, df[col])
+        benchmark(clean_series_values, df[col])
 
     # do something else here?
     assert 1 == 1

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -382,22 +382,22 @@ class TestDatatypeHandling:
             df.index = df[dtype].copy()
         df = normalize_index_and_columns(df)
 
+        try:
+            build_table_schema(df, index=False)
+        except Exception as e:
+            assert False, f"{dtype} failed pandas build_table_schema(): {e}"
+
+        try:
+            json_clean(df.reset_index().to_dict("records"))
+        except Exception as e:
+            assert False, f"{dtype} failed jupyter_client json_clean(): {e}"
+
+        try:
+            get_db_connection().register("test", df)
+        except Exception as e:
+            assert False, f"{dtype} failed duckdb register(): {e}"
+
         with settings_context(display_mode="simple"):
-            try:
-                build_table_schema(df, index=False)
-            except Exception as e:
-                assert False, f"{dtype} failed pandas build_table_schema(): {e}"
-
-            try:
-                json_clean(df.reset_index().to_dict("records"))
-            except Exception as e:
-                assert False, f"{dtype} failed jupyter_client json_clean(): {e}"
-
-            try:
-                get_db_connection().register("test", df)
-            except Exception as e:
-                assert False, f"{dtype} failed duckdb register(): {e}"
-
             try:
                 handle_format(df)
             except Exception as e:

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -20,7 +20,7 @@ from dx.datatypes.main import (
     quick_random_dataframe,
     random_dataframe,
 )
-from dx.utils.formatting import clean_column_values
+from dx.utils.formatting import clean_series_values
 from dx.utils.tracking import generate_df_hash
 
 
@@ -65,7 +65,7 @@ def test_generate_df_hash(dtype: str):
     params[dtype] = True
     df = random_dataframe(**params)
     for col in df.columns:
-        df[col] = clean_column_values(df[col])
+        df[col] = clean_series_values(df[col])
     try:
         hash_str = generate_df_hash(df)
     except Exception as e:
@@ -104,7 +104,7 @@ def test_store_in_db(dtype: str, sample_db_connection: duckdb.DuckDBPyConnection
     df = random_dataframe(**params)
 
     for col in df.columns:
-        df[col] = clean_column_values(df[col])
+        df[col] = clean_series_values(df[col])
 
     try:
         sample_db_connection.register(f"{dtype}_test", df)
@@ -149,7 +149,7 @@ class TestDataFrameGeneration:
 class TestDatatypeHandling:
     def test_integer_series_left_alone(self):
         series = numeric.generate_integer_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "int64"
         assert isinstance(
             series.values[0], (int, np.int64)
@@ -157,7 +157,7 @@ class TestDatatypeHandling:
 
     def test_float_series_left_alone(self):
         series = numeric.generate_float_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "float64"
         assert isinstance(
             series.values[0], (float, np.float64)
@@ -165,7 +165,7 @@ class TestDatatypeHandling:
 
     def test_boolean_series_left_alone(self):
         series = misc.generate_boolean_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "bool"
         assert isinstance(
             series.values[0], (bool, np.bool_)
@@ -173,7 +173,7 @@ class TestDatatypeHandling:
 
     def test_dtype_series_converted(self):
         series = misc.generate_dtype_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -181,7 +181,7 @@ class TestDatatypeHandling:
 
     def test_decimal_series_converted(self):
         series = numeric.generate_decimal_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "float64"
         assert isinstance(
             series.values[0], (float, np.float64)
@@ -189,7 +189,7 @@ class TestDatatypeHandling:
 
     def test_datetime_series_left_alone(self):
         series = date_time.generate_datetime_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         # may have tzinfo, which will be `datetime64[ns, tz]`
         assert str(series.dtype).startswith("datetime64[ns"), f"{series.dtype=}"
         assert isinstance(
@@ -198,7 +198,7 @@ class TestDatatypeHandling:
 
     def test_datetimetz_series_converted(self):
         series = date_time.generate_datetimetz_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert str(series.dtype).startswith("datetime64[ns, ")
         assert isinstance(
             series.values[0], (datetime, np.datetime64)
@@ -213,7 +213,7 @@ class TestDatatypeHandling:
         tz_series = date_time.generate_datetimetz_series(5)
         series = tz_naive_series.append(tz_series)
         assert series.dtype == "object"
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert str(series.dtype).startswith("datetime64[ns")
         assert isinstance(
             series.values[0], (datetime, np.datetime64)
@@ -222,7 +222,7 @@ class TestDatatypeHandling:
     def test_date_series_converted(self):
         # datetime.date values are converted to pd.Timestamp
         series = date_time.generate_date_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "datetime64[ns]"
         assert isinstance(
             series.values[0], (datetime, np.datetime64)
@@ -231,7 +231,7 @@ class TestDatatypeHandling:
     def test_time_series_converted(self):
         # datetime.time values are converted to strings
         series = date_time.generate_time_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -240,7 +240,7 @@ class TestDatatypeHandling:
     def test_timedelta_series_converted(self):
         # time delta values are converted to floats (total seconds)
         series = date_time.generate_time_delta_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "float64"
         assert isinstance(
             series.values[0], (float, np.float64)
@@ -248,7 +248,7 @@ class TestDatatypeHandling:
 
     def test_time_period_series_converted(self):
         series = date_time.generate_time_period_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -256,7 +256,7 @@ class TestDatatypeHandling:
 
     def test_time_interval_series_converted(self):
         series = date_time.generate_time_interval_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -264,7 +264,7 @@ class TestDatatypeHandling:
 
     def test_text_series_left_alone(self):
         series = text.generate_text_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -272,7 +272,7 @@ class TestDatatypeHandling:
 
     def test_keyword_series_left_alone(self):
         series = text.generate_keyword_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -281,7 +281,7 @@ class TestDatatypeHandling:
     def test_dict_series_converted(self):
         # dictionary values are JSON-stringifed
         series = misc.generate_dict_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -290,7 +290,7 @@ class TestDatatypeHandling:
     def test_list_series_converted(self):
         # sequence values are cast as strings
         series = misc.generate_list_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -299,7 +299,7 @@ class TestDatatypeHandling:
     def test_nested_tabular_series_converted(self):
         # lists of dictionaries are JSON-stringified
         series = main.generate_nested_tabular_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -308,7 +308,7 @@ class TestDatatypeHandling:
     def test_latlon_point_series_converted(self):
         # latlon point values are converted to GeoJSON strings
         series = geometry.generate_latlon_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -318,7 +318,7 @@ class TestDatatypeHandling:
         # shapely.geometry values are converted to GeoJSON strings
         # by handle_geometry_series()
         series = geometry.generate_filled_geojson_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -328,7 +328,7 @@ class TestDatatypeHandling:
         # shapely.geometry exterior values are converted to GeoJSON strings
         # by handle_geometry_series()
         series = geometry.generate_exterior_bounds_geojson_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -337,7 +337,7 @@ class TestDatatypeHandling:
     def test_bytes_series_converted(self):
         # bytes values are converted to strings
         series = misc.generate_bytes_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -346,7 +346,7 @@ class TestDatatypeHandling:
     def test_ipv4_address_series_converted(self):
         # IPv4Address values are converted to strings
         series = misc.generate_ipv4_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str
@@ -355,7 +355,7 @@ class TestDatatypeHandling:
     def test_ipv6_address_series_converted(self):
         # IPv6Address values are converted to strings
         series = misc.generate_ipv6_series(5)
-        series = clean_column_values(series)
+        series = clean_series_values(series)
         assert series.dtype == "object"
         assert isinstance(
             series.values[0], str


### PR DESCRIPTION
Renames `clean_column_values` to `clean_series_values` and ensures we're cleaning indices for data types like we do for columns.

Adds a new test to make sure `normalize_index_and_columns()` behaves like we want.

Before:
![image](https://github.com/noteable-io/dx/assets/7707189/38973df7-62b0-4af8-85cc-ada1855cae95)

After:
![image](https://github.com/noteable-io/dx/assets/7707189/939bda81-03bd-4b2c-b520-133f70a440d5)

