### PR TITLE
fix comparison with NaNs

### DIFF
--- a/src/dx/utils/tracking.py
+++ b/src/dx/utils/tracking.py
@@ -186,7 +186,10 @@ def get_df_variable_name(
         # ...and for any non-pandas DataFrame objects, we need to convert them so
         # equality checks pass and we properly detect the matching variable
         other_df = to_dataframe(v)
-        if df.equals(other_df):
+        # ......also, in the event we have NaNs/NAs, we can't correctly compare values from one
+        # dataframe to another, so we need to compare the string representations of the values to
+        # avoid making things more complicated than they already are
+        if df.astype(str).equals(other_df.astype(str)):
             logger.debug(f"`{k}` matches this dataframe")
             matching_df_vars.append(k)
     logger.debug(f"dataframe variables with same data: {matching_df_vars}")


### PR DESCRIPTION
Previous tests broke for geodataframes since comparing the `geometry` columns that contained `Point(value, NaN)` would evaluate to false and not match correctly.
![image](https://github.com/noteable-io/dx/assets/7707189/e3a6fd86-171c-4bad-bc57-c43f8d9ae01a)

```
FAILED tests/test_renderable_types.py::TestRenderableTypes::test_non_pandas_dataframes[simple-True-geopandas] - AssertionError: assert 'unk_datafram...4d0eb41b576e7' == 'test_df'
    - test_df
    + unk_dataframe_94faf76d674849278374d0eb41b576e7
assert False
```
